### PR TITLE
Finish Android validation

### DIFF
--- a/Examples/strings-base.xml
+++ b/Examples/strings-base.xml
@@ -14,9 +14,12 @@
 
     <!-- Phrase templates -->
     <string name="could_not_add_collaborator_to_object">Could not add {user_name} to \"{object_name}\"</string>
+    <string name="translation_has_missing_phrase">Could not add {user_name} to \"{object_name}\"</string>
 
     <!-- Native templates -->
     <string name="group_members_with_count">%1$s (%2$d)</string>
+    <string name="translation_has_invalid_specifier">%s %d</string>
+    <string name="translation_has_missing_arg">%s %d</string>
 
     <!-- Non-translatable (missing from translation, will not show warning) -->
     <string name="photos_icon_content_description" translatable="false">Photos</string>

--- a/Examples/strings-translation.xml
+++ b/Examples/strings-translation.xml
@@ -14,9 +14,12 @@
 
     <!-- Phrase templates -->
     <string name="could_not_add_collaborator_to_object">{user_name} konnte nicht zu „{object_name}“ hinzugefügt werden</string>
+    <string name="translation_has_missing_phrase">Could not add {user_name}</string>
 
     <!-- Native templates -->
     <string name="group_members_with_count">%1$s (%2$d)</string>
+    <string name="translation_has_invalid_specifier">%s %lu</string>
+    <string name="translation_has_missing_arg">%s</string>
 
     <!-- Missing from base -->
     <string name="missing_from_base">Missing from base</string>

--- a/Examples/strings-translation.xml
+++ b/Examples/strings-translation.xml
@@ -9,7 +9,7 @@
     <!-- Native plurals -->
     <plurals name="number_of_errors">
         <item quantity="one">Ein Fehler ist aufgetreten.</item>
-        <item quantity="other"> %d Fehler sind aufgetreten.</item>
+        <item quantity="other">%d Fehler sind aufgetreten.</item>
     </plurals>
 
     <!-- Phrase templates -->

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "SwiftyXMLParser",
-        "repositoryURL": "https://github.com/yahoojapan/SwiftyXMLParser",
+        "repositoryURL": "https://github.com/stevelandeyasana/SwiftyXMLParser",
         "state": {
-          "branch": null,
-          "revision": "ec7f183642adf429babd867d1a38c5c6912408ba",
-          "version": "5.3.0"
+          "branch": "locheck",
+          "revision": "f1317db8b4ca1a9e2ea5766419c47293ddabd4d5",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.4.0")),
         .package(url: "https://github.com/johnsundell/Files.git", .upToNextMinor(from: "4.2.0")),
-        .package(url: "https://github.com/yahoojapan/SwiftyXMLParser", .upToNextMinor(from: "5.3.0")),
+        // Use Steve's fork of SwiftyXMLParser until changes are upstreamed
+        .package(url: "https://github.com/stevelandeyasana/SwiftyXMLParser", .branch("locheck")),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Other install methods may be added upon request as we discover people's needs. T
 
 ## Usage
 
-There are a few ways to invoke `locheck` depending on how much magic you want.
+There are a few ways to invoke `locheck` depending on how much magic you want. In all cases, Locheck will write to stderr for Xcode integration, and stdout for a human-readable summary. Pull requests for additional output formats will probably be accepted.
 
 ### `discoverlproj`
 
@@ -88,6 +88,8 @@ locheck discovervalues ./commons/src/main/res
 ### Other ways
 
 Run `locheck --help` to see a list of all commands. The rest of the commands just let you directly compare individual files of different types.
+
+## Example output
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://opensource.org/licenses/MIT)
 [![Build](https://github.com/stevelandeyasana/locheck/actions/workflows/tests.yml/badge.svg)](https://github.com/stevelandeyasana/locheck/actions/workflows/tests.yml)
 
-An Xcode localization file validator. Make sure your `.strings` files do not have any errors!
+An Xcode and Android localization file validator. Make sure your `.strings`, `.stringsdict`, and `strings.xml` files do not have any errors!
 
 ## What does it do?
 
@@ -83,9 +83,17 @@ You can directly compare `.strings` files against each other. Again, pass the ba
 locheck xcstrings MyApp/en.lproj/Localizable.strings MyApp/fr.lproj/Localizable.strings
 ```
 
+### `xcstringsdict`
+
+You can directly compare `.stringsdict` files against each other. Again, pass the base language first, followed by the rest.
+
+```sh
+locheck xcstrings MyApp/en.lproj/Localizable.stringsdict MyApp/fr.lproj/Localizable.stringsdict
+```
+
 ### `androidstrings` (experimental!)
 
-You can directly compare `android.xml` files against each other. Locheck only looks for missing keys.
+You can directly compare `android.xml` files against each other.
 
 ```sh
 locheck androidstrings ./common/src/main/res/values/strings.xml ./common/src/main/res/values-LANG/strings.xml

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ An Xcode and Android localization file validator. Make sure your `.strings`, `.s
 
 ## What does it do?
 
-Locheck can perform two kinds of checks on `.strings` files.
-1. A string appears in `Localizable.strings` for your base language but is missing elsewhere. This is a source of UI bugs.
-2. A translated string uses incorrect arguments, for example a mismatched specifier or invalid position. This is a source of crashes:
+Locheck can perform many kinds of checks on localization files. The simplest one is making sure all strings appear in both the base language and translations, but it can also make sure all your format specifiers are consistent, even in `.stringsdict` files.
 
 Consider this string:
 
@@ -18,10 +16,22 @@ Consider this string:
 "Send %d donuts to %@" = "%@ to donuts %d send";
 ```
 
-The translation reads naturally on its own, but this would crash your app when iOS tries to format a number as an Objective-C object and and Objective-C object as a number. Instead, it should look like this:
+```xml
+<!-- values/strings.xml -->
+<string name="send_donuts">Send %d donuts to %s</string>
+<!-- values-translation/strings.xml -->
+<string name="send_donuts">%s to donuts %d send</string>
+```
+
+The translation reads naturally on its own, but this would crash your app when iOS or Android tries to format a number as a string and a string as a number. Instead, the translation should look like this:
 
 ```swift
 "Send %d donuts to %@" = "%1$@ to donuts %2$d send";
+```
+
+```xml
+<!-- values-translation/strings.xml -->
+<string name="send_donuts">%1$s to donuts %2$d send</string>
 ```
 
 Locheck will make sure you get it right.
@@ -51,53 +61,33 @@ mint install Asana/locheck --link
 locheck [...]
 ```
 
-Other install methods may be added upon request as we discover people's needs.
+Other install methods may be added upon request as we discover people's needs. This project is very new and setting up new installation methods takes time.
 
 ## Usage
 
-There are three ways to invoke `locheck` depending on how much magic you want.
+There are a few ways to invoke `locheck` depending on how much magic you want.
 
-### `discover`
+### `discoverlproj`
 
-The simplest way is to use `discover` and point to a directory containing all your `.lproj` files:
+The simplest way to use Locheck with Xcode is to use `discoverlproj` and point to a directory containing all your `.lproj` files:
 
 ```sh
-locheck discover "MyApp/Supporting Files" --default en # use English as the base language
+locheck discoverlproj "MyApp/Supporting Files" --default en # use English as the base language
 ```
 
 If you use a language besides English as your base, you'll need to pass it as an argument as shown in the example. Locheck does not try to read your xcodeproj file to figure it out.
 
-### `lproj`
+### `discovervalues`
 
-You can pass a list of `lproj` files to `locheck lproj`, starting with the base language.
-
-```sh
-locheck lproj MyApp/en.lproj MyApp/fr.lproj
-```
-
-### `xcstrings`
-
-You can directly compare `.strings` files against each other. Again, pass the base language first, followed by the rest.
+The simplest way to use Locheck on Android is to use `discovervalues` and point to a directory containing all your `values[-*]` directories, i.e. your `res/` directory.
 
 ```sh
-locheck xcstrings MyApp/en.lproj/Localizable.strings MyApp/fr.lproj/Localizable.strings
+locheck discovervalues ./commons/src/main/res
 ```
 
-### `xcstringsdict`
+### Other ways
 
-You can directly compare `.stringsdict` files against each other. Again, pass the base language first, followed by the rest.
-
-```sh
-locheck xcstrings MyApp/en.lproj/Localizable.stringsdict MyApp/fr.lproj/Localizable.stringsdict
-```
-
-### `androidstrings` (experimental!)
-
-You can directly compare `android.xml` files against each other.
-
-```sh
-locheck androidstrings ./common/src/main/res/values/strings.xml ./common/src/main/res/values-LANG/strings.xml
-```
+Run `locheck --help` to see a list of all commands. The rest of the commands just let you directly compare individual files of different types.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The translation reads naturally on its own, but this would crash your app when i
 
 ```xml
 <!-- values-translation/strings.xml -->
-<string name="send_donuts">%1$s to donuts %2$d send</string>
+<string name="send_donuts">%2$s to donuts %1$d send</string>
 ```
 
 Locheck will make sure you get it right.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Translations to check: 12
 /.../android/commons/src/main/res/values-ko/strings.xml:1426: warning: 'created_video_phrase_template' does not include argument(s): author_name (phrase_has_missing_arguments)
 [...]
 
-SUMMARY:
+Summary:
 /.../android/commons/src/main/res/values-ko/strings.xml
     could_not_mark_as_milestone:
         ERROR: Translation of 'could_not_mark_as_milestone' includes arguments that don't exist in the source: task_name

--- a/README.md
+++ b/README.md
@@ -91,6 +91,35 @@ Run `locheck --help` to see a list of all commands. The rest of the commands jus
 
 ## Example output
 
+```
+> locheck discovervalues $ANDROID/commons/src/main/res --ignore key_missing_from_translation --ignore key_missing_from_base
+Discovering values[-*]/strings.xml files in /.../android/commons/src/main/res
+Source of truth: /.../android/commons/src/main/res/values/strings.xml
+Translations to check: 12
+/.../android/commons/src/main/res/values-de/strings.xml:242: error: Translation of 'could_not_mark_as_milestone' includes arguments that don't exist in the source: task_name (string_has_extra_arguments)
+/.../android/commons/src/main/res/values-de/strings.xml:899: warning: 'organization_required_mfa_help_text' does not include argument(s): authy_url, duo_mobile_url, microsoft_authenticator_url (phrase_has_missing_arguments)
+/.../android/commons/src/main/res/values-ko/strings.xml:1403: error: Translation of 'what_are_a_few_tasks_you_have_to_do_for_project_name' includes arguments that don't exist in the source: projectName (string_has_extra_arguments)
+/.../android/commons/src/main/res/values-ko/strings.xml:1426: warning: 'created_video_phrase_template' does not include argument(s): author_name (phrase_has_missing_arguments)
+[...]
+
+SUMMARY:
+/.../android/commons/src/main/res/values-ko/strings.xml
+    could_not_mark_as_milestone:
+        ERROR: Translation of 'could_not_mark_as_milestone' includes arguments that don't exist in the source: task_name
+    created_video_phrase_template:
+        WARNING: 'created_video_phrase_template' does not include argument(s): author_name
+        ERROR: Translation of 'created_video_phrase_template' includes arguments that don't exist in the source: userName1
+    organization_required_mfa_help_text:
+        WARNING: 'organization_required_mfa_help_text' does not include argument(s): authy_url, duo_mobile_url, microsoft_authenticator_url
+    what_are_a_few_tasks_you_have_to_do_for_project_name:
+        WARNING: 'what_are_a_few_tasks_you_have_to_do_for_project_name' does not include argument(s): project_name
+        ERROR: Translation of 'what_are_a_few_tasks_you_have_to_do_for_project_name' includes arguments that don't exist in the source: projectName
+[...]
+20 warnings, 29 errors
+Ignored key_missing_from_translation, key_missing_from_base
+Errors found
+```
+
 ## Contributing
 
 GitHub issues and pull requests are very welcome! Please format your code with `swiftformat Sources Tests` before opening your PR, otherwise tests will fail and we cannot merge your branch. We also run SwiftLint to help ensure best practices.

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -307,8 +307,8 @@ struct DiscoverValues: ParsableCommand {
                 return // caught by validation already
             }
 
-            print("Source of truth: \(primaryValues)")
-            print("Translations to check: \(translationValues)")
+            print("Source of truth: \(primaryValues.path)")
+            print("Translations to check: \(translationValues.count)")
 
             withProblemReporter(ignore: ignore) { problemReporter in
                 for translation in translationValues {

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -211,7 +211,6 @@ struct DiscoverLproj: ParsableCommand {
         }
     }
 
-    // TODO: Use two different commands
     func run() {
         for directory in directories {
             print("Discovering .lproj files in \(directory.argument)")
@@ -281,7 +280,6 @@ struct DiscoverValues: ParsableCommand {
         }
     }
 
-    // TODO: Use two different commands
     func run() {
         for directory in directories {
             print("Discovering values[-*]/strings.xml files in \(directory.argument)")

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -100,7 +100,6 @@ struct AndroidStrings: ParsableCommand {
                     problemReporter: problemReporter)
             }
             problemReporter.printSummary()
-            print("Be aware that Android validation is incomplete.")
         }
     }
 }

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -46,7 +46,7 @@ struct XCStrings: ParsableCommand {
     private var translation: [FileArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore: [String]
+    private var ignore = [String]()
 
     func validate() throws {
         try base.validate(ext: "strings")
@@ -80,7 +80,7 @@ struct AndroidStrings: ParsableCommand {
     private var translation: [FileArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore: [String]
+    private var ignore = [String]()
 
     func validate() throws {
         try base.validate(ext: "xml")
@@ -117,7 +117,7 @@ struct Stringsdict: ParsableCommand {
     private var translation: [FileArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore: [String]
+    private var ignore = [String]()
 
     func validate() throws {
         try base.validate(ext: "stringsdict")
@@ -150,7 +150,7 @@ struct Lproj: ParsableCommand {
     private var translation: [DirectoryArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore: [String]
+    private var ignore = [String]()
 
     func validate() throws {
         try base.validate(ext: "lproj")
@@ -183,7 +183,7 @@ struct Discover: ParsableCommand {
     private var directories: [DirectoryArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore: [String]
+    private var ignore = [String]()
 
     func validate() throws {
         for directory in directories {

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -32,6 +32,8 @@ private func withProblemReporter(ignore: [String], _ block: (ProblemReporter) ->
     print("Finished validating")
 }
 
+private let ignoreHelpText: ArgumentHelp = "Ignore a rule completely. The most common values are key_missing_from_base and key_missing_from_translation, for when you know keys are missing and it's OK."
+
 struct XCStrings: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "xcstrings",
@@ -43,7 +45,7 @@ struct XCStrings: ParsableCommand {
     @Argument(help: "Non-authoritative .strings files that need to be validated")
     private var translation: [FileArg]
 
-    @Option(help: "Add a rule to ignore completely")
+    @Option(help: ignoreHelpText)
     private var ignore: [String]
 
     func validate() throws {
@@ -77,7 +79,7 @@ struct AndroidStrings: ParsableCommand {
     @Argument(help: "Non-authoritative strings.xml files that need to be validated")
     private var translation: [FileArg]
 
-    @Option(help: "Add a rule to ignore completely")
+    @Option(help: ignoreHelpText)
     private var ignore: [String]
 
     func validate() throws {
@@ -114,7 +116,7 @@ struct Stringsdict: ParsableCommand {
     @Argument(help: "Non-authoritative .stringsdict files that need to be validated")
     private var translation: [FileArg]
 
-    @Option(help: "Add a rule to ignore completely")
+    @Option(help: ignoreHelpText)
     private var ignore: [String]
 
     func validate() throws {
@@ -147,7 +149,7 @@ struct Lproj: ParsableCommand {
     @Argument(help: "Non-authoritative .lproj directories that need to be validated")
     private var translation: [DirectoryArg]
 
-    @Option(help: "Add a rule to ignore completely")
+    @Option(help: ignoreHelpText)
     private var ignore: [String]
 
     func validate() throws {
@@ -180,7 +182,7 @@ struct Discover: ParsableCommand {
     @Argument(help: "One or more directories full of .lproj files, with one of them being authoritative.")
     private var directories: [DirectoryArg]
 
-    @Option(help: "Add a rule to ignore completely")
+    @Option(help: ignoreHelpText)
     private var ignore: [String]
 
     func validate() throws {

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -19,7 +19,14 @@ struct Locheck: ParsableCommand {
         .lproj files, `lproj` operates on specific .lproj files, and `strings` operates on
         specific .strings files.
         """,
-        subcommands: [DiscoverLproj.self, DiscoverValues.self, Lproj.self, XCStrings.self, Stringsdict.self, AndroidStrings.self])
+        subcommands: [
+            DiscoverLproj.self,
+            DiscoverValues.self,
+            Lproj.self,
+            XCStrings.self,
+            Stringsdict.self,
+            AndroidStrings.self,
+        ])
 }
 
 private func withProblemReporter(ignore: [String], _ block: (ProblemReporter) -> Void) {
@@ -32,7 +39,8 @@ private func withProblemReporter(ignore: [String], _ block: (ProblemReporter) ->
     print("Finished validating")
 }
 
-private let ignoreHelpText: ArgumentHelp = "Ignore a rule completely. The most common values are key_missing_from_base and key_missing_from_translation, for when you know keys are missing and it's OK."
+private let ignoreHelpText: ArgumentHelp =
+    "Ignore a rule completely. The most common values are key_missing_from_base and key_missing_from_translation, for when you know keys are missing and it's OK."
 
 struct XCStrings: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -180,7 +188,8 @@ struct DiscoverLproj: ParsableCommand {
     @Option(help: "The authoritative language. Defaults to 'en'. ")
     private var base = "en"
 
-    @Argument(help: "One or more directories full of .lproj files, with one of them being authoritative (defined by --base).")
+    @Argument(
+        help: "One or more directories full of .lproj files, with one of them being authoritative (defined by --base).")
     private var directories: [DirectoryArg]
 
     @Option(help: ignoreHelpText)
@@ -199,7 +208,6 @@ struct DiscoverLproj: ParsableCommand {
                 } else {
                     hasTranslation = true
                 }
-
             }
 
             if !hasBase {

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -40,7 +40,10 @@ private func withProblemReporter(ignore: [String], _ block: (ProblemReporter) ->
 }
 
 private let ignoreHelpText: ArgumentHelp =
-    "Ignore a rule completely. The most common values are key_missing_from_base and key_missing_from_translation, for when you know keys are missing and it's OK."
+    "Ignore a rule completely."
+
+private let ignoreMissingHelpText: ArgumentHelp =
+    "Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'."
 
 struct XCStrings: ParsableCommand {
     static let configuration = CommandConfiguration(
@@ -56,13 +59,20 @@ struct XCStrings: ParsableCommand {
     @Option(help: ignoreHelpText)
     private var ignore = [String]()
 
+    @Flag(help: ignoreMissingHelpText)
+    private var ignoreMissing = false
+
+    private var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
+
     func validate() throws {
         try base.validate(ext: "strings")
         try translation.forEach { try $0.validate(ext: "strings") }
     }
 
     func run() {
-        withProblemReporter(ignore: ignore) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
             for file in translation {
                 let translationFile = try! File(path: file.argument)
                 parseAndValidateXCStrings(
@@ -90,13 +100,20 @@ struct AndroidStrings: ParsableCommand {
     @Option(help: ignoreHelpText)
     private var ignore = [String]()
 
+    @Flag(help: ignoreMissingHelpText)
+    private var ignoreMissing = false
+
+    private var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
+
     func validate() throws {
         try base.validate(ext: "xml")
         try translation.forEach { try $0.validate(ext: "xml") }
     }
 
     func run() {
-        withProblemReporter(ignore: ignore) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
             for file in translation {
                 let translationFile = try! File(path: file.argument)
                 var translationLanguageName = translationFile.parent!.nameExcludingExtension
@@ -127,13 +144,20 @@ struct Stringsdict: ParsableCommand {
     @Option(help: ignoreHelpText)
     private var ignore = [String]()
 
+    @Flag(help: ignoreMissingHelpText)
+    private var ignoreMissing = false
+
+    private var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
+
     func validate() throws {
         try base.validate(ext: "stringsdict")
         try translation.forEach { try $0.validate(ext: "stringsdict") }
     }
 
     func run() {
-        withProblemReporter(ignore: ignore) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
             for file in translation {
                 let translationFile = try! File(path: file.argument)
                 parseAndValidateStringsdict(
@@ -160,6 +184,13 @@ struct Lproj: ParsableCommand {
     @Option(help: ignoreHelpText)
     private var ignore = [String]()
 
+    @Flag(help: ignoreMissingHelpText)
+    private var ignoreMissing = false
+
+    private var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
+
     func validate() throws {
         try base.validate(ext: "lproj")
         try translation.forEach { try $0.validate(ext: "lproj") }
@@ -168,7 +199,7 @@ struct Lproj: ParsableCommand {
     func run() {
         print("Validating \(translation.count) lproj files against \(try! Folder(path: base.argument).name)")
 
-        withProblemReporter(ignore: ignore) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
             for translation in translation {
                 validateLproj(
                     base: LprojFiles(folder: try! Folder(path: base.argument)),
@@ -194,6 +225,13 @@ struct DiscoverLproj: ParsableCommand {
 
     @Option(help: ignoreHelpText)
     private var ignore = [String]()
+
+    @Flag(help: ignoreMissingHelpText)
+    private var ignoreMissing = false
+
+    private var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
 
     func validate() throws {
         for directory in directories {
@@ -241,7 +279,7 @@ struct DiscoverLproj: ParsableCommand {
             print("Source of truth: \(baseLproj.path)")
             print("Translations to check: \(translationLproj.count)")
 
-            withProblemReporter(ignore: ignore) { problemReporter in
+            withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
                 for translation in translationLproj {
                     validateLproj(base: baseLproj, translation: translation, problemReporter: problemReporter)
                 }
@@ -261,6 +299,13 @@ struct DiscoverValues: ParsableCommand {
 
     @Option(help: ignoreHelpText)
     private var ignore = [String]()
+
+    @Flag(help: ignoreMissingHelpText)
+    private var ignoreMissing = false
+
+    private var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
 
     func validate() throws {
         for directory in directories {
@@ -310,7 +355,7 @@ struct DiscoverValues: ParsableCommand {
             print("Source of truth: \(primaryValues.path)")
             print("Translations to check: \(translationValues.count)")
 
-            withProblemReporter(ignore: ignore) { problemReporter in
+            withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
                 for translation in translationValues {
                     parseAndValidateAndroidStrings(
                         base: primaryValues,

--- a/Sources/LocheckLogic/Extensions/Sequence+locheck.swift
+++ b/Sources/LocheckLogic/Extensions/Sequence+locheck.swift
@@ -16,7 +16,8 @@ extension Sequence {
         return dict
     }
 
-    func lo_makeDictionary<Key, Value>(makeKey: (Element) -> Key, makeValue: (Element) -> Value) -> [Key: Value] where Key: Hashable {
+    func lo_makeDictionary<Key, Value>(makeKey: (Element) -> Key, makeValue: (Element) -> Value) -> [Key: Value]
+        where Key: Hashable {
         var dict = [Key: Value]()
         for item in self {
             dict[makeKey(item)] = makeValue(item)

--- a/Sources/LocheckLogic/Extensions/Sequence+locheck.swift
+++ b/Sources/LocheckLogic/Extensions/Sequence+locheck.swift
@@ -15,4 +15,12 @@ extension Sequence {
         }
         return dict
     }
+
+    func lo_makeDictionary<Key, Value>(makeKey: (Element) -> Key, makeValue: (Element) -> Value) -> [Key: Value] where Key: Hashable {
+        var dict = [Key: Value]()
+        for item in self {
+            dict[makeKey(item)] = makeValue(item)
+        }
+        return dict
+    }
 }

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -84,7 +84,7 @@ public class ProblemReporter {
             problemsByFile[localProblem.path]!.append(localProblem)
         }
 
-        print("\nSUMMARY:")
+        print("\nSummary:")
 
         for path in problemsByFile.keys.sorted() {
             print(path)

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -40,11 +40,11 @@ public protocol SummarizableProblem: Problem {
 public class ProblemReporter {
     public struct LocalProblem: Error, Equatable {
         public let path: String
-        public let lineNumber: Int?
+        public let lineNumber: Int
         public let problem: Problem
 
         var messageForXcode: String {
-            "\(path):\(lineNumber ?? 0): \(problem.severity.rawValue): \(problem.message) (\(problem.kindIdentifier))"
+            "\(path):\(lineNumber): \(problem.severity.rawValue): \(problem.message) (\(problem.kindIdentifier))"
         }
 
         public static func == (a: LocalProblem, b: LocalProblem) -> Bool {
@@ -63,7 +63,7 @@ public class ProblemReporter {
         self.ignoredProblemIdentifiers = Set(ignoredProblemIdentifiers)
     }
 
-    public func report(_ problem: Problem, path: String, lineNumber: Int?) {
+    public func report(_ problem: Problem, path: String, lineNumber: Int) {
         guard !ignoredProblemIdentifiers.contains(problem.kindIdentifier) else { return }
         let localProblem = LocalProblem(path: path, lineNumber: lineNumber, problem: problem)
         problems.append(localProblem)

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -98,8 +98,8 @@ public class ProblemReporter {
             }
         }
 
-        let warningCount = problems.filter({ $0.problem.severity == .warning }).count
-        let errorCount = problems.filter({ $0.problem.severity == .error }).count
+        let warningCount = problems.filter { $0.problem.severity == .warning }.count
+        let errorCount = problems.filter { $0.problem.severity == .error }.count
         let aggregates: [String] = [
             warningCount == 1 ? "1 warning" : "\(warningCount) warnings",
             errorCount == 1 ? "1 error" : "\(errorCount) errors",
@@ -107,7 +107,7 @@ public class ProblemReporter {
         print(aggregates.joined(separator: ", "))
 
         if !ignoredProblemIdentifiers.isEmpty {
-            print("Ignored", ignoredProblemIdentifiers.joined(separator: (", ")))
+            print("Ignored", ignoredProblemIdentifiers.joined(separator: ", "))
         }
     }
 

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -56,12 +56,15 @@ public class ProblemReporter {
     public private(set) var problems = [LocalProblem]()
 
     public var log: Bool
+    public let ignoredProblemIdentifiers: Set<String>
 
-    public init(log: Bool = true) {
+    public init(log: Bool = true, ignoredProblemIdentifiers: [String] = []) {
         self.log = log
+        self.ignoredProblemIdentifiers = Set(ignoredProblemIdentifiers)
     }
 
     public func report(_ problem: Problem, path: String, lineNumber: Int?) {
+        guard !ignoredProblemIdentifiers.contains(problem.kindIdentifier) else { return }
         let localProblem = LocalProblem(path: path, lineNumber: lineNumber, problem: problem)
         problems.append(localProblem)
 

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -92,11 +92,20 @@ public class ProblemReporter {
             let keys = Set(problems.map(\.key))
             for key in keys.sorted() {
                 print("  \(key):")
-                for problem in problems.filter({ $0.key == key }).map(\.message).sorted() {
-                    print("    \(problem)")
+                for problem in problems.filter({ $0.key == key }) {
+                    print("    \(problem.severity.rawValue.uppercased()): \(problem.message)")
                 }
             }
         }
+
+        let warningCount = problems.filter({ $0.problem.severity == .warning }).count
+        let errorCount = problems.filter({ $0.problem.severity == .error }).count
+        let aggregates: [String] = [
+            warningCount == 1 ? "1 warning" : "\(warningCount) warnings",
+            errorCount == 1 ? "1 error" : "\(errorCount) errors",
+        ]
+        print(aggregates.joined(separator: ", "))
+        print("Ignored", ignoredProblemIdentifiers.joined(separator: (", ")))
     }
 
     /**

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -105,7 +105,10 @@ public class ProblemReporter {
             errorCount == 1 ? "1 error" : "\(errorCount) errors",
         ]
         print(aggregates.joined(separator: ", "))
-        print("Ignored", ignoredProblemIdentifiers.joined(separator: (", ")))
+
+        if !ignoredProblemIdentifiers.isEmpty {
+            print("Ignored", ignoredProblemIdentifiers.joined(separator: (", ")))
+        }
     }
 
     /**

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -89,6 +89,17 @@ struct PhraseHasMissingArguments: Problem, StringsProblem, Equatable {
     var message: String { "'\(key)' does not include argument(s): \(args.joined(separator: ", "))" }
 }
 
+struct PhraseHasExtraArguments: Problem, StringsProblem, Equatable {
+    var kindIdentifier: String { "string_has_extra_arguments" }
+    var uniquifyingInformation: String { "\(language)-\(key)" }
+    var severity: Severity { .error }
+    let key: String
+    let language: String
+    let args: [String]
+
+    var message: String { "Translation of '\(key)' includes arguments that don't exist in the source: \(args.joined(separator: ", "))" }
+}
+
 struct StringHasDuplicateArguments: Problem, StringsProblem, Equatable {
     var kindIdentifier: String { "string_has_duplicate_arguments" }
     var uniquifyingInformation: String { "\(language)-\(key)" }
@@ -110,7 +121,7 @@ struct StringHasExtraArguments: Problem, StringsProblem, Equatable {
     let args: [String]
 
     var message: String {
-        "Translation includes arguments that don't exist in the source: \(args.joined(separator: ", "))"
+        "Translation of '\(key)' includes arguments that don't exist in the source: \(args.joined(separator: ", "))"
     }
 }
 

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -97,7 +97,9 @@ struct PhraseHasExtraArguments: Problem, StringsProblem, Equatable {
     let language: String
     let args: [String]
 
-    var message: String { "Translation of '\(key)' includes arguments that don't exist in the source: \(args.joined(separator: ", "))" }
+    var message: String {
+        "Translation of '\(key)' includes arguments that don't exist in the source: \(args.joined(separator: ", "))"
+    }
 }
 
 struct StringHasDuplicateArguments: Problem, StringsProblem, Equatable {

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -69,6 +69,15 @@ struct LprojFileMissingFromTranslation: Problem, Equatable {
     var message: String { "\(key) missing from \(language)" }
 }
 
+struct PhraseAndNativeArgumentsAreBothPresent: Problem, StringsProblem, Equatable {
+    var kindIdentifier: String { "phrase_and_native_arguments_are_both_present" }
+    var uniquifyingInformation: String { key }
+    var severity: Severity { .warning }
+    let key: String
+
+    var message: String { "'\(key)' contains both native (%d) and phrase-style ({arg}) arguments" }
+}
+
 struct PhraseHasMissingArguments: Problem, StringsProblem, Equatable {
     var kindIdentifier: String { "phrase_has_missing_arguments" }
     var uniquifyingInformation: String { "\(language)-\(key)" }
@@ -77,7 +86,7 @@ struct PhraseHasMissingArguments: Problem, StringsProblem, Equatable {
     let language: String
     let args: [String]
 
-    var message: String { "Does not include argument(s): \(args.joined(separator: ", "))" }
+    var message: String { "'\(key)' does not include argument(s): \(args.joined(separator: ", "))" }
 }
 
 struct StringHasDuplicateArguments: Problem, StringsProblem, Equatable {

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -15,6 +15,15 @@ protocol StringsProblem: SummarizableProblem {
     var key: String { get }
 }
 
+struct CDATACannotBeDecoded: Problem, Equatable {
+    var kindIdentifier: String { "cdata_cannot_be_decoded" }
+    var uniquifyingInformation: String { "\(key)" }
+    var severity: Severity { .error }
+    let key: String
+
+    var message: String { "'\(key)' has CDATA that cannot be decoded as UTF-8" }
+}
+
 struct DuplicateEntries: Problem, Equatable {
     var kindIdentifier: String { "duplicate_entries" }
     var uniquifyingInformation: String { "\(context ?? "<root>")-\(name)" }

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -60,6 +60,17 @@ struct LprojFileMissingFromTranslation: Problem, Equatable {
     var message: String { "\(key) missing from \(language)" }
 }
 
+struct PhraseHasMissingArguments: Problem, StringsProblem, Equatable {
+    var kindIdentifier: String { "phrase_has_missing_arguments" }
+    var uniquifyingInformation: String { "\(language)-\(key)" }
+    var severity: Severity { .warning }
+    let key: String
+    let language: String
+    let args: [String]
+
+    var message: String { "Does not include argument(s): \(args.joined(separator: ", "))" }
+}
+
 struct StringHasDuplicateArguments: Problem, StringsProblem, Equatable {
     var kindIdentifier: String { "string_has_duplicate_arguments" }
     var uniquifyingInformation: String { "\(language)-\(key)" }
@@ -108,7 +119,7 @@ struct StringHasMissingArguments: Problem, StringsProblem, Equatable {
     let language: String
     let args: [String]
 
-    var message: String { "Does not include argument(s) at \(args.joined(separator: ", "))" }
+    var message: String { "'\(key)' does not include argument(s) at \(args.joined(separator: ", "))" }
 }
 
 struct StringsdictEntryContainsNoVariablesProblem: Problem, StringsdictProblem, Equatable {

--- a/Sources/LocheckLogic/Types/AndroidStringsFile.swift
+++ b/Sources/LocheckLogic/Types/AndroidStringsFile.swift
@@ -63,9 +63,21 @@ extension AndroidStringsFile {
 
             switch element.name {
             case "string":
-                strings.append(AndroidString(
-                    key: key,
-                    value: FormatString(string: element.text ?? "", path: path, line: nil)))
+                if let cdata = element.CDATA {
+                    guard let string = String(data: cdata, encoding: .utf8) else {
+                        problemReporter.report(CDATACannotBeDecoded(key: key), path: path, lineNumber: nil)
+                        continue
+                    }
+                    strings.append(
+                        AndroidString(
+                            key: key,
+                            value: FormatString(string: string, path: path, line: nil)))
+                } else {
+                    strings.append(
+                        AndroidString(
+                            key: key,
+                            value: FormatString(string: element.text ?? "", path: path, line: nil)))
+                }
             case "plurals":
                 var values = [String: FormatString]()
                 for child in element.childElements {

--- a/Sources/LocheckLogic/Types/AndroidStringsFile.swift
+++ b/Sources/LocheckLogic/Types/AndroidStringsFile.swift
@@ -18,14 +18,14 @@ struct AndroidString: Equatable {
     let value: FormatString
 }
 
-struct AndroidStringsFile: Equatable {
+public struct AndroidStringsFile: Equatable {
     let path: String
     let strings: [AndroidString]
     let plurals: [AndroidPlural]
 }
 
 extension AndroidStringsFile {
-    init?(path: String, problemReporter: ProblemReporter) {
+    public init?(path: String, problemReporter: ProblemReporter) {
         self.path = path
         guard let xml = parseXML(file: try! File(path: path), problemReporter: problemReporter) else {
             return nil

--- a/Sources/LocheckLogic/Types/AndroidStringsFile.swift
+++ b/Sources/LocheckLogic/Types/AndroidStringsFile.swift
@@ -27,8 +27,8 @@ public struct AndroidStringsFile: Equatable {
     let plurals: [AndroidPlural]
 }
 
-extension AndroidStringsFile {
-    public init?(path: String, problemReporter: ProblemReporter) {
+public extension AndroidStringsFile {
+    init?(path: String, problemReporter: ProblemReporter) {
         self.path = path
         guard let xml = parseXML(file: try! File(path: path), problemReporter: problemReporter) else {
             return nil
@@ -55,7 +55,10 @@ extension AndroidStringsFile {
                 continue
             }
             guard !seenKeys.contains(key) else {
-                problemReporter.report(DuplicateEntries(context: nil, name: key), path: path, lineNumber: element.lineNumberStart)
+                problemReporter.report(
+                    DuplicateEntries(context: nil, name: key),
+                    path: path,
+                    lineNumber: element.lineNumberStart)
                 continue
             }
             seenKeys.insert(key)
@@ -68,7 +71,10 @@ extension AndroidStringsFile {
             case "string":
                 if let cdata = element.CDATA {
                     guard let string = String(data: cdata, encoding: .utf8) else {
-                        problemReporter.report(CDATACannotBeDecoded(key: key), path: path, lineNumber: element.lineNumberStart)
+                        problemReporter.report(
+                            CDATACannotBeDecoded(key: key),
+                            path: path,
+                            lineNumber: element.lineNumberStart)
                         continue
                     }
                     strings.append(

--- a/Sources/LocheckLogic/Types/FormatArgument.swift
+++ b/Sources/LocheckLogic/Types/FormatArgument.swift
@@ -10,7 +10,7 @@ import Foundation
 /// The contents of one "%d" or "%2$@" argument. (These would be
 /// `FormatArgument(specifier: "d", position: <automatic>)` and
 /// `FormatArgument(specifier: "@", position: 2)`, respectively.)
-struct FormatArgument: Equatable {
+struct FormatArgument: Equatable, Hashable {
     let specifier: String
     let position: Int
     let isPositionExplicit: Bool

--- a/Sources/LocheckLogic/Types/FormatString.swift
+++ b/Sources/LocheckLogic/Types/FormatString.swift
@@ -21,10 +21,10 @@ struct FormatString: Equatable {
     let arguments: [FormatArgument]
     let phraseArguments: [String]
     let path: String
-    let line: Int?
+    let line: Int
     let kind: Kind
 
-    init(string: String, path: String, line: Int?) {
+    init(string: String, path: String, line: Int) {
         self.string = string
         self.path = path
         self.line = line

--- a/Sources/LocheckLogic/Types/LocalizedStringPair.swift
+++ b/Sources/LocheckLogic/Types/LocalizedStringPair.swift
@@ -21,14 +21,14 @@ struct LocalizedStringPair: Equatable {
     let base: FormatString
     let translation: FormatString
     let path: String
-    let line: Int?
+    let line: Int
 }
 
 extension LocalizedStringPair {
     init?(
         string: String,
         path: String,
-        line: Int?,
+        line: Int,
         baseStringMap: [String: FormatString]? = nil) { // only pass for translation strings
         guard
             let match = Expressions.stringPairRegex.lo_matches(in: string).first,

--- a/Sources/LocheckLogic/Types/Stringsdict.swift
+++ b/Sources/LocheckLogic/Types/Stringsdict.swift
@@ -45,7 +45,7 @@ struct Stringsdict: Equatable {
             problemReporter.report(
                 XMLSchemaProblem(message: "XML schema error: no dict at top level"),
                 path: path,
-                lineNumber: nil)
+                lineNumber: 0)
             return nil
         }
 

--- a/Sources/LocheckLogic/Types/StringsdictEntry.swift
+++ b/Sources/LocheckLogic/Types/StringsdictEntry.swift
@@ -255,7 +255,9 @@ extension StringsdictEntry {
             switch valueKey {
             case "NSStringLocalizedFormatKey":
                 guard valueNode.name == "string" else {
-                    report(XMLSchemaProblem(message: "Unexpected value for key \(valueKey): \(valueNode.name)"), valueNode.lineNumberStart)
+                    report(
+                        XMLSchemaProblem(message: "Unexpected value for key \(valueKey): \(valueNode.name)"),
+                        valueNode.lineNumberStart)
                     return nil
                 }
                 maybeFormatKey = valueText

--- a/Sources/LocheckLogic/Types/StringsdictEntry.swift
+++ b/Sources/LocheckLogic/Types/StringsdictEntry.swift
@@ -12,20 +12,20 @@ import SwiftyXMLParser
 /// for a system of rules defining a set of strings.
 struct StringsdictEntry: Equatable {
     let key: String
+    let line: Int
     let formatKey: LexedStringsdictString
     let rules: [String: StringsdictRule] // derived from XML
 
     func validateRuleVariables(path: String, problemReporter: ProblemReporter) {
         let checkRule = { (ruleKey: String, variables: [String]) -> Void in
             for variable in variables where rules[variable] == nil {
-                // lineNumber is nil because we don't have it from SwiftyXMLParser.
                 problemReporter.report(
                     StringsdictEntryHasMissingVariable(
                         key: key,
                         variable: variable,
                         ruleKey: ruleKey),
                     path: path,
-                    lineNumber: nil)
+                    lineNumber: line)
             }
         }
 
@@ -56,12 +56,11 @@ struct StringsdictEntry: Equatable {
         // but that would require us to remember which span of each string maps back to which variable,
         // which is a lot of extra bookkeeping to do at this stage of the project.
 
-        let report = { (problem: Problem) -> Void in
-            // lineNumber is nil because we don't have it from SwiftyXMLParser.
-            problemReporter.report(problem, path: path, lineNumber: nil)
+        let report = { (problem: Problem, line: Int) -> Void in
+            problemReporter.report(problem, path: path, lineNumber: line)
         }
 
-        let permutations = allPermutations.map { FormatString(string: $0, path: path, line: nil) }
+        let permutations = allPermutations.map { FormatString(string: $0, path: path, line: line) }
         let numArgs = permutations.flatMap(\.arguments).reduce(0) { max($0, $1.position) }
         var arguments = [FormatArgument?]((0 ..< numArgs).map { _ in nil })
         var originalStringForArgument = [String]((0 ..< numArgs).map { _ in "" })
@@ -73,7 +72,8 @@ struct StringsdictEntry: Equatable {
                         StringsdictEntryHasImplicitPosition(
                             key: key,
                             position: arg.position,
-                            permutation: string.string))
+                            permutation: string.string),
+                        line)
                 }
 
                 // Remember arg positions are 1-indexed!
@@ -87,7 +87,8 @@ struct StringsdictEntry: Equatable {
                                 permutation1: originalString,
                                 permutation2: string.string,
                                 specifier1: oldArg.specifier,
-                                specifier2: arg.specifier))
+                                specifier2: arg.specifier),
+                            line)
                     }
                 } else {
                     originalStringForArgument[arg.position - 1] = string.string
@@ -101,7 +102,8 @@ struct StringsdictEntry: Equatable {
             report(
                 StringsdictEntryHasUnusedArguments(
                     key: key,
-                    positions: unusedArguments))
+                    positions: unusedArguments),
+                line)
         }
 
         return arguments
@@ -232,9 +234,10 @@ struct StringsdictEntry: Equatable {
 
 extension StringsdictEntry {
     init?(key: String, node: XML.Element, path: String, problemReporter: ProblemReporter) {
-        let report = { (problem: Problem) -> Void in
-            // lineNumber is nil because we don't have it from SwiftyXMLParser.
-            problemReporter.report(problem, path: path, lineNumber: nil)
+        line = node.lineNumberStart
+
+        let report = { (problem: Problem, line: Int) -> Void in
+            problemReporter.report(problem, path: path, lineNumber: line)
         }
 
         var maybeFormatKey: String?
@@ -246,13 +249,13 @@ extension StringsdictEntry {
             path: path,
             problemReporter: problemReporter) {
             guard let valueText = valueNode.text else {
-                report(XMLSchemaProblem(message: "No value for key \(key).\(valueKey)"))
+                report(XMLSchemaProblem(message: "No value for key \(key).\(valueKey)"), valueNode.lineNumberStart)
                 return nil
             }
             switch valueKey {
             case "NSStringLocalizedFormatKey":
                 guard valueNode.name == "string" else {
-                    report(XMLSchemaProblem(message: "Unexpected value for key \(valueKey): \(valueNode.name)"))
+                    report(XMLSchemaProblem(message: "Unexpected value for key \(valueKey): \(valueNode.name)"), valueNode.lineNumberStart)
                     return nil
                 }
                 maybeFormatKey = valueText
@@ -272,14 +275,15 @@ extension StringsdictEntry {
         }
 
         guard let formatKey = maybeFormatKey else {
-            report(XMLSchemaProblem(message: "\(key) contains no value for NSStringLocalizedFormatKey"))
+            report(XMLSchemaProblem(message: "\(key) contains no value for NSStringLocalizedFormatKey"), line)
             return nil
         }
         if maybeOrderedRuleKeys == nil {
             report(
                 StringsdictEntryHasNoVariables(
                     key: key,
-                    formatKey: formatKey))
+                    formatKey: formatKey),
+                line)
         }
         var hasAllVariables = true
         for variableKey in maybeOrderedRuleKeys ?? [] where rules[variableKey] == nil {
@@ -287,7 +291,8 @@ extension StringsdictEntry {
                 StringsdictEntryHasMissingVariable(
                     key: key,
                     variable: variableKey,
-                    ruleKey: "format key"))
+                    ruleKey: "format key"),
+                line)
             hasAllVariables = false
         }
 

--- a/Sources/LocheckLogic/Types/StringsdictRule.swift
+++ b/Sources/LocheckLogic/Types/StringsdictRule.swift
@@ -13,6 +13,7 @@ import SwiftyXMLParser
  */
 struct StringsdictRule: Equatable {
     let key: String
+    let line: Int
     let specType: String
     let valueType: String
     let alternatives: [String: LexedStringsdictString]
@@ -20,9 +21,10 @@ struct StringsdictRule: Equatable {
 
 extension StringsdictRule {
     init?(key: String, node: XML.Element, path: String, problemReporter: ProblemReporter) {
+        self.line = node.lineNumberStart
+
         let report = { (problem: Problem) -> Void in
-            // lineNumber is nil because we don't have it from SwiftyXMLParser.
-            problemReporter.report(problem, path: path, lineNumber: nil)
+            problemReporter.report(problem, path: path, lineNumber: node.lineNumberStart)
         }
 
         var maybeSpecType: String?

--- a/Sources/LocheckLogic/Types/StringsdictRule.swift
+++ b/Sources/LocheckLogic/Types/StringsdictRule.swift
@@ -21,7 +21,7 @@ struct StringsdictRule: Equatable {
 
 extension StringsdictRule {
     init?(key: String, node: XML.Element, path: String, problemReporter: ProblemReporter) {
-        self.line = node.lineNumberStart
+        line = node.lineNumberStart
 
         let report = { (problem: Problem) -> Void in
             problemReporter.report(problem, path: path, lineNumber: node.lineNumberStart)

--- a/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
@@ -91,11 +91,11 @@ func validateAndroidStrings(
         }
         if !argsMissingFromBase.isEmpty {
             problemReporter.report(
-                StringHasMissingArguments(
-                    key: baseString.key,
+                StringHasExtraArguments(
+                    key: translationString.key,
                     language: translationLanguageName,
                     args: Array(argsMissingFromTranslation.sorted().map { String($0) })),
-                path: base.path,
+                path: translation.path,
                 lineNumber:  baseString.line)
         }
         if !phraseMissingFromTranslation.isEmpty {
@@ -109,11 +109,11 @@ func validateAndroidStrings(
         }
         if !phraseMissingFromBase.isEmpty {
             problemReporter.report(
-                PhraseHasMissingArguments(
+                PhraseHasExtraArguments(
                     key: translationString.key,
                     language: translationLanguageName,
                     args: Array(phraseMissingFromBase).sorted()),
-                path: base.path,
+                path: translation.path,
                 lineNumber: baseString.line)
         }
 

--- a/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
@@ -13,10 +13,9 @@ public func parseAndValidateAndroidStrings(
     translation translationFile: File,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
-    guard let base = AndroidStringsFile(path: baseFile.path, problemReporter: problemReporter) else {
-        return
-    }
-    guard let translation = AndroidStringsFile(path: translationFile.path, problemReporter: problemReporter) else {
+    guard
+        let base = AndroidStringsFile(path: baseFile.path, problemReporter: problemReporter),
+        let translation = AndroidStringsFile(path: translationFile.path, problemReporter: problemReporter) else {
         return
     }
 
@@ -66,6 +65,13 @@ func validateAndroidStrings(
 
         guard translationArgs != baseArgs || translationPhraseArgs != basePhraseArgs else {
             continue // no errors
+        }
+
+        if !translationPhraseArgs.isEmpty && !translationArgs.isEmpty {
+            problemReporter.report(
+                PhraseAndNativeArgumentsAreBothPresent(key: translationString.key),
+                path: translation.path,
+                lineNumber: nil)
         }
 
         let argsMissingFromTranslation = Set(baseArgs.map(\.position)).subtracting(Set(translationArgs.map(\.position)))

--- a/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
@@ -58,9 +58,9 @@ func validateAndroidStrings(
             continue // We already threw an error for this in validateKeyPresence()
         }
 
-        let baseArgs = baseString.value.arguments
+        let baseArgs = baseString.value.arguments.sorted(by: { $0.position < $1.position })
         let basePhraseArgs = baseString.value.phraseArguments
-        let translationArgs = translationString.value.arguments
+        let translationArgs = translationString.value.arguments.sorted(by: { $0.position < $1.position })
         let translationPhraseArgs = translationString.value.phraseArguments
 
         guard translationArgs != baseArgs || translationPhraseArgs != basePhraseArgs else {
@@ -114,6 +114,24 @@ func validateAndroidStrings(
                     args: Array(phraseMissingFromBase).sorted()),
                 path: base.path,
                 lineNumber: nil)
+        }
+
+
+        for arg in translationString.value.arguments {
+            guard let baseArg = baseArgs.first(where: { $0.position == arg.position }) else {
+                continue // we already logged an error for this above
+            }
+            if arg.specifier != baseArg.specifier {
+                problemReporter.report(
+                    StringHasInvalidArgument(
+                        key: translationString.key,
+                        language: translationLanguageName,
+                        argPosition: arg.position,
+                        baseArgSpecifier: baseArg.specifier,
+                        argSpecifier: arg.specifier),
+                    path: translation.path,
+                    lineNumber: nil)
+            }
         }
     }
 }

--- a/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
@@ -71,7 +71,7 @@ func validateAndroidStrings(
             problemReporter.report(
                 PhraseAndNativeArgumentsAreBothPresent(key: translationString.key),
                 path: translation.path,
-                lineNumber: nil)
+                lineNumber: translationString.line)
         }
 
         let argsMissingFromTranslation = Set(baseArgs.map(\.position)).subtracting(Set(translationArgs.map(\.position)))
@@ -86,7 +86,7 @@ func validateAndroidStrings(
                     language: translationLanguageName,
                     args: Array(argsMissingFromTranslation.sorted().map { String($0) })),
                 path: translation.path,
-                lineNumber: nil)
+                lineNumber: translationString.line)
         }
         if !argsMissingFromBase.isEmpty {
             problemReporter.report(
@@ -95,7 +95,7 @@ func validateAndroidStrings(
                     language: translationLanguageName,
                     args: Array(argsMissingFromTranslation.sorted().map { String($0) })),
                 path: base.path,
-                lineNumber: nil)
+                lineNumber:  baseString.line)
         }
         if !phraseMissingFromTranslation.isEmpty {
             problemReporter.report(
@@ -104,7 +104,7 @@ func validateAndroidStrings(
                     language: translationLanguageName,
                     args: Array(phraseMissingFromTranslation).sorted()),
                 path: translation.path,
-                lineNumber: nil)
+                lineNumber: translationString.line)
         }
         if !phraseMissingFromBase.isEmpty {
             problemReporter.report(
@@ -113,7 +113,7 @@ func validateAndroidStrings(
                     language: translationLanguageName,
                     args: Array(phraseMissingFromBase).sorted()),
                 path: base.path,
-                lineNumber: nil)
+                lineNumber: baseString.line)
         }
 
 
@@ -130,7 +130,7 @@ func validateAndroidStrings(
                         baseArgSpecifier: baseArg.specifier,
                         argSpecifier: arg.specifier),
                     path: translation.path,
-                    lineNumber: nil)
+                    lineNumber: translationString.line)
             }
         }
     }

--- a/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
@@ -31,7 +31,6 @@ func validateAndroidStrings(
     translation: AndroidStringsFile,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
-
     validateKeyPresence(
         basePath: base.path,
         baseKeys: Set(base.strings.map(\.key)),
@@ -96,7 +95,7 @@ func validateAndroidStrings(
                     language: translationLanguageName,
                     args: Array(argsMissingFromTranslation.sorted().map { String($0) })),
                 path: translation.path,
-                lineNumber:  baseString.line)
+                lineNumber: baseString.line)
         }
         if !phraseMissingFromTranslation.isEmpty {
             problemReporter.report(
@@ -116,7 +115,6 @@ func validateAndroidStrings(
                 path: translation.path,
                 lineNumber: baseString.line)
         }
-
 
         for arg in translationString.value.arguments {
             guard let baseArg = baseArgs.first(where: { $0.position == arg.position }) else {

--- a/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateAndroidStrings.swift
@@ -31,23 +31,24 @@ func validateAndroidStrings(
     translation: AndroidStringsFile,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
+
     validateKeyPresence(
         basePath: base.path,
         baseKeys: Set(base.strings.map(\.key)),
-        baseLineNumberMap: [:], // don't have line numbers
+        baseLineNumberMap: base.strings.lo_makeDictionary(makeKey: \.key, makeValue: \.line),
         translationPath: translation.path,
         translationKeys: Set(translation.strings.map(\.key)),
-        translationLineNumberMap: [:], // don't have line numbers
+        translationLineNumberMap: translation.strings.lo_makeDictionary(makeKey: \.key, makeValue: \.line),
         translationLanguageName: translationLanguageName,
         problemReporter: problemReporter)
 
     validateKeyPresence(
         basePath: base.path,
         baseKeys: Set(base.plurals.map(\.key)),
-        baseLineNumberMap: [:], // don't have line numbers
+        baseLineNumberMap: base.plurals.lo_makeDictionary(makeKey: \.key, makeValue: \.line),
         translationPath: translation.path,
         translationKeys: Set(translation.plurals.map(\.key)),
-        translationLineNumberMap: [:], // don't have line numbers
+        translationLineNumberMap: translation.plurals.lo_makeDictionary(makeKey: \.key, makeValue: \.line),
         translationLanguageName: translationLanguageName,
         problemReporter: problemReporter)
 

--- a/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
@@ -31,7 +31,6 @@ func validateStringsdict(
     translation translationStringsdict: Stringsdict,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
-
     validateKeyPresence(
         basePath: baseStringsdict.path,
         baseKeys: Set(baseStringsdict.entries.map(\.key)),

--- a/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
@@ -35,10 +35,10 @@ func validateStringsdict(
     validateKeyPresence(
         basePath: baseStringsdict.path,
         baseKeys: Set(baseStringsdict.entries.map(\.key)),
-        baseLineNumberMap: [:], // don't have line numbers
+        baseLineNumberMap: baseStringsdict.entries.lo_makeDictionary(makeKey: \.key, makeValue: \.line),
         translationPath: translationStringsdict.path,
         translationKeys: Set(translationStringsdict.entries.map(\.key)),
-        translationLineNumberMap: [:], // don't have line numbers
+        translationLineNumberMap: translationStringsdict.entries.lo_makeDictionary(makeKey: \.key, makeValue: \.line),
         translationLanguageName: translationLanguageName,
         problemReporter: problemReporter)
 

--- a/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
@@ -8,34 +8,6 @@
 import Files
 import Foundation
 
-func validateKeyPresence(
-    basePath: String,
-    baseKeys: Set<String>,
-    baseLineNumberMap: [String: Int],
-    translationPath: String,
-    translationKeys: Set<String>,
-    translationLineNumberMap: [String: Int],
-    translationLanguageName: String,
-    problemReporter: ProblemReporter) {
-    for key in baseKeys.sorted() {
-        if !translationKeys.contains(key) {
-            problemReporter.report(
-                KeyMissingFromTranslation(key: key, language: translationLanguageName),
-                path: basePath,
-                lineNumber: baseLineNumberMap[key])
-        }
-    }
-
-    for key in translationKeys.sorted() {
-        if !baseKeys.contains(key) {
-            problemReporter.report(
-                KeyMissingFromBase(key: key),
-                path: translationPath,
-                lineNumber: translationLineNumberMap[key])
-        }
-    }
-}
-
 public func parseAndValidateStringsdict(
     base baseFile: File,
     translation translationFile: File,

--- a/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
@@ -119,7 +119,7 @@ func validateStrings(
 
         for arg in translationString.translation.arguments {
             guard let baseArg = baseArgs.first(where: { $0.position == arg.position }) else {
-                continue
+                continue // we already logged an error for this above
             }
             if arg.specifier != baseArg.specifier {
                 problemReporter.report(

--- a/Sources/LocheckLogic/Validators/validateKeyPresence.swift
+++ b/Sources/LocheckLogic/Validators/validateKeyPresence.swift
@@ -17,20 +17,26 @@ func validateKeyPresence(
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
     for key in baseKeys.sorted() {
+        if baseLineNumberMap[key] == nil {
+            print("You found a bug in validateKeyPresence()")
+        }
         if !translationKeys.contains(key) {
             problemReporter.report(
                 KeyMissingFromTranslation(key: key, language: translationLanguageName),
                 path: basePath,
-                lineNumber: baseLineNumberMap[key])
+                lineNumber: baseLineNumberMap[key] ?? 0)
         }
     }
 
     for key in translationKeys.sorted() {
+        if translationLineNumberMap[key] == nil {
+            print("You found a bug in validateKeyPresence()")
+        }
         if !baseKeys.contains(key) {
             problemReporter.report(
                 KeyMissingFromBase(key: key),
                 path: translationPath,
-                lineNumber: translationLineNumberMap[key])
+                lineNumber: translationLineNumberMap[key] ?? 0)
         }
     }
 }

--- a/Sources/LocheckLogic/Validators/validateKeyPresence.swift
+++ b/Sources/LocheckLogic/Validators/validateKeyPresence.swift
@@ -1,6 +1,6 @@
 //
 //  validateKeyPresence.swift
-//  
+//
 //
 //  Created by Steve Landey on 9/1/21.
 //

--- a/Sources/LocheckLogic/Validators/validateKeyPresence.swift
+++ b/Sources/LocheckLogic/Validators/validateKeyPresence.swift
@@ -1,0 +1,36 @@
+//
+//  validateKeyPresence.swift
+//  
+//
+//  Created by Steve Landey on 9/1/21.
+//
+
+import Foundation
+
+func validateKeyPresence(
+    basePath: String,
+    baseKeys: Set<String>,
+    baseLineNumberMap: [String: Int],
+    translationPath: String,
+    translationKeys: Set<String>,
+    translationLineNumberMap: [String: Int],
+    translationLanguageName: String,
+    problemReporter: ProblemReporter) {
+    for key in baseKeys.sorted() {
+        if !translationKeys.contains(key) {
+            problemReporter.report(
+                KeyMissingFromTranslation(key: key, language: translationLanguageName),
+                path: basePath,
+                lineNumber: baseLineNumberMap[key])
+        }
+    }
+
+    for key in translationKeys.sorted() {
+        if !baseKeys.contains(key) {
+            problemReporter.report(
+                KeyMissingFromBase(key: key),
+                path: translationPath,
+                lineNumber: translationLineNumberMap[key])
+        }
+    }
+}

--- a/Sources/LocheckLogic/Validators/validateLproj.swift
+++ b/Sources/LocheckLogic/Validators/validateLproj.swift
@@ -19,7 +19,7 @@ public func validateLproj(base: LprojFiles, translation: LprojFiles, problemRepo
                     key: stringsFile.name,
                     language: translation.name),
                 path: stringsFile.path,
-                lineNumber: nil)
+                lineNumber: 0)
             continue
         }
         parseAndValidateXCStrings(
@@ -38,7 +38,7 @@ public func validateLproj(base: LprojFiles, translation: LprojFiles, problemRepo
                     key: baseStringsdictFile.name,
                     language: translation.name),
                 path: baseStringsdictFile.path,
-                lineNumber: nil)
+                lineNumber: 0)
             continue
         }
         parseAndValidateStringsdict(

--- a/Sources/LocheckLogic/parseXML.swift
+++ b/Sources/LocheckLogic/parseXML.swift
@@ -16,7 +16,7 @@ func parseXML(file: File, problemReporter: ProblemReporter) -> XML.Accessor? {
         problemReporter.report(
             XMLErrorProblem(message: error.localizedDescription),
             path: file.path,
-            lineNumber: nil)
+            lineNumber: 0)
         return nil
     }
 }

--- a/Sources/LocheckLogic/readPlistDict.swift
+++ b/Sources/LocheckLogic/readPlistDict.swift
@@ -16,7 +16,7 @@ func readPlistDict(
         problemReporter.report(
             XMLSchemaProblem(message: "Malformed plist; object isn't a dict"),
             path: path,
-            lineNumber: nil)
+            lineNumber: root.lineNumberStart)
         return []
     }
     var results = [(String, XML.Element)]()
@@ -25,7 +25,7 @@ func readPlistDict(
             problemReporter.report(
                 XMLSchemaProblem(message: "Malformed plist; can't find next key in dict"),
                 path: path,
-                lineNumber: nil)
+                lineNumber: root.childElements[i].lineNumberStart)
             return []
         }
         results.append((key, root.childElements[i + 1]))

--- a/Tests/LocheckCommandTests/Asserts.swift
+++ b/Tests/LocheckCommandTests/Asserts.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  Asserts.swift
+//
 //
 //  Created by Steve Landey on 9/1/21.
 //

--- a/Tests/LocheckCommandTests/Asserts.swift
+++ b/Tests/LocheckCommandTests/Asserts.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Steve Landey on 9/1/21.
+//
+
+import Foundation
+import XCTest
+
+func CastAndAssertEqual<T: Equatable>(
+    _ a: Any?,
+    _ b: T,
+    file: StaticString = #file,
+    line: UInt = #line) {
+    XCTAssertEqual(a as? T, b)
+}

--- a/Tests/LocheckCommandTests/ExecutableTests.swift
+++ b/Tests/LocheckCommandTests/ExecutableTests.swift
@@ -57,29 +57,30 @@ class ExecutableTests: XCTestCase {
         SUMMARY:
         Examples/Demo_Base.strings
           missing:
-            'missing' is missing from Demo_Translation
+            WARNING: 'missing' is missing from Demo_Translation
         Examples/Demo_Translation.strings
           bad pos %ld %@:
-            Does not include argument(s) at 1
-            Some arguments appear more than once in this translation
-            Specifier for argument 2 does not match (should be @, is ld)
+            WARNING: 'bad pos %ld %@' does not include argument(s) at 1
+            WARNING: Some arguments appear more than once in this translation
+            ERROR: Specifier for argument 2 does not match (should be @, is ld)
           bad position %d:
-            Does not include argument(s) at 1
+            WARNING: 'bad position %d' does not include argument(s) at 1
           mismatch %@ types %d:
-            Specifier for argument 1 does not match (should be @, is d)
-            Specifier for argument 2 does not match (should be d, is @)
+            ERROR: Specifier for argument 2 does not match (should be d, is @)
+            ERROR: Specifier for argument 1 does not match (should be @, is d)
+        4 warnings, 3 errors
         Errors found
 
         """)
 
-        XCTAssertEqual(stderr, """
+        XCTAssertEqual(stderr!, """
         Examples/Demo_Base.strings:3: warning: 'missing' is missing from Demo_Translation (key_missing_from_translation)
-        Examples/Demo_Translation.strings:3: warning: Does not include argument(s) at 1 (string_has_missing_arguments)
+        Examples/Demo_Translation.strings:3: warning: 'bad pos %ld %@' does not include argument(s) at 1 (string_has_missing_arguments)
         Examples/Demo_Translation.strings:3: warning: Some arguments appear more than once in this translation (string_has_duplicate_arguments)
         Examples/Demo_Translation.strings:3: error: Specifier for argument 2 does not match (should be @, is ld) (string_has_invalid_argument)
         Examples/Demo_Translation.strings:5: error: Specifier for argument 2 does not match (should be d, is @) (string_has_invalid_argument)
         Examples/Demo_Translation.strings:5: error: Specifier for argument 1 does not match (should be @, is d) (string_has_invalid_argument)
-        Examples/Demo_Translation.strings:7: warning: Does not include argument(s) at 1 (string_has_missing_arguments)
+        Examples/Demo_Translation.strings:7: warning: 'bad position %d' does not include argument(s) at 1 (string_has_missing_arguments)
 
         """)
     }
@@ -107,27 +108,28 @@ class ExecutableTests: XCTestCase {
         SUMMARY:
         Examples/Demo_Base.stringsdict
           %d/%d Completed:
-            '%d/%d Completed' is missing from Demo_Translation
+            WARNING: '%d/%d Completed' is missing from Demo_Translation
           missing from translation:
-            'missing from translation' is missing from Demo_Translation
+            WARNING: 'missing from translation' is missing from Demo_Translation
         Examples/Demo_Translation.stringsdict
           Every %d week(s) on %lu days:
-            'Every %d week(s) on %lu days' does not use argument 1
-            No permutation of 'Every %d week(s) on %lu days' use argument(s) at position 1
-            Two permutations of 'Every %d week(s) on %lu days' contain different format specifiers at position 2. '%2$lu jours toutes les %d semaines' uses 'lu', and '%2$lu jours toutes les %d semaines' uses 'd'.
+            ERROR: Two permutations of 'Every %d week(s) on %lu days' contain different format specifiers at position 2. '%2$lu jours toutes les %d semaines' uses 'lu', and '%2$lu jours toutes les %d semaines' uses 'd'.
+            WARNING: No permutation of 'Every %d week(s) on %lu days' use argument(s) at position 1
+            WARNING: 'Every %d week(s) on %lu days' does not use argument 1
           missing from base:
-            'missing from base' is missing from the base translation
+            WARNING: 'missing from base' is missing from the base translation
+        5 warnings, 1 error
         Errors found
 
         """)
 
-        XCTAssertEqual(stderr, """
-        Examples/Demo_Base.stringsdict:0: warning: '%d/%d Completed' is missing from Demo_Translation (key_missing_from_translation)
-        Examples/Demo_Base.stringsdict:0: warning: 'missing from translation' is missing from Demo_Translation (key_missing_from_translation)
-        Examples/Demo_Translation.stringsdict:0: warning: 'missing from base' is missing from the base translation (key_missing_from_base)
-        Examples/Demo_Translation.stringsdict:0: error: Two permutations of 'Every %d week(s) on %lu days' contain different format specifiers at position 2. '%2$lu jours toutes les %d semaines' uses 'lu', and '%2$lu jours toutes les %d semaines' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)
-        Examples/Demo_Translation.stringsdict:0: warning: No permutation of 'Every %d week(s) on %lu days' use argument(s) at position 1 (stringsdict_entry_has_unused_arguments)
-        Examples/Demo_Translation.stringsdict:0: warning: 'Every %d week(s) on %lu days' does not use argument 1 (stringsdict_entry_missing_argument)
+        XCTAssertEqual(stderr!, """
+        Examples/Demo_Base.stringsdict:22: warning: '%d/%d Completed' is missing from Demo_Translation (key_missing_from_translation)
+        Examples/Demo_Base.stringsdict:63: warning: 'missing from translation' is missing from Demo_Translation (key_missing_from_translation)
+        Examples/Demo_Translation.stringsdict:22: warning: 'missing from base' is missing from the base translation (key_missing_from_base)
+        Examples/Demo_Translation.stringsdict:6: error: Two permutations of 'Every %d week(s) on %lu days' contain different format specifiers at position 2. '%2$lu jours toutes les %d semaines' uses 'lu', and '%2$lu jours toutes les %d semaines' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)
+        Examples/Demo_Translation.stringsdict:6: warning: No permutation of 'Every %d week(s) on %lu days' use argument(s) at position 1 (stringsdict_entry_has_unused_arguments)
+        Examples/Demo_Translation.stringsdict:6: warning: 'Every %d week(s) on %lu days' does not use argument 1 (stringsdict_entry_missing_argument)
 
         """)
     }

--- a/Tests/LocheckCommandTests/ExecutableTests.swift
+++ b/Tests/LocheckCommandTests/ExecutableTests.swift
@@ -54,7 +54,7 @@ class ExecutableTests: XCTestCase {
         XCTAssertEqual(stdout!, """
         Validating Examples/Demo_Translation.strings against Examples/Demo_Base.strings
 
-        SUMMARY:
+        Summary:
         Examples/Demo_Base.strings
           missing:
             WARNING: 'missing' is missing from Demo_Translation
@@ -105,7 +105,7 @@ class ExecutableTests: XCTestCase {
 
         XCTAssertEqual(stdout!, """
 
-        SUMMARY:
+        Summary:
         Examples/Demo_Base.stringsdict
           %d/%d Completed:
             WARNING: '%d/%d Completed' is missing from Demo_Translation

--- a/Tests/LocheckCommandTests/LocalizedStringPairTests.swift
+++ b/Tests/LocheckCommandTests/LocalizedStringPairTests.swift
@@ -17,7 +17,7 @@ class LocalizedStringPairTests: XCTestCase {
             "%1$@ %2$d %@" = "%1$@ %2$d %@";
             """,
             path: "abc",
-            line: nil)!
+            line: 0)!
         XCTAssertEqual(
             string.base.arguments,
             [
@@ -35,7 +35,7 @@ class LocalizedStringPairTests: XCTestCase {
             "A sync error occurred while creating column “%@” in project “%@”." = "Er is een synchronisatiefout opgetreden tijdens het maken van kolom “%@” in een project.";
             """,
             path: "abc",
-            line: nil)!
+            line: 0)!
         XCTAssertEqual(
             string.base.arguments,
             [
@@ -55,7 +55,7 @@ class LocalizedStringPairTests: XCTestCase {
             "A sync error occurred while processing %@'s request to join “%@”." = "“%@” 님의 “%2$@” 참가 요청을 처리하는 중 동기화 오류가 발생했습니다.";
             """,
             path: "abc",
-            line: nil)!
+            line: 0)!
         XCTAssertEqual(
             string.base.arguments,
             [

--- a/Tests/LocheckCommandTests/StringsdictEntryTests.swift
+++ b/Tests/LocheckCommandTests/StringsdictEntryTests.swift
@@ -13,10 +13,12 @@ class StringsdictEntryTests: XCTestCase {
     func testMissingVariableInRoot() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "%#@def@ %#@xyz@"), // def exists, xyz doesn't
             rules: [
                 "def": StringsdictRule(
                     key: "def",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -27,17 +29,19 @@ class StringsdictEntryTests: XCTestCase {
         let problemReporter = ProblemReporter(log: false)
         entry.validateRuleVariables(path: "en.stringsdict", problemReporter: problemReporter)
         XCTAssertEqual(problemReporter.problems.map(\.messageForXcode), [
-            "en.stringsdict:0: error: Variable xyz does not exist in 'abc' but is used in the format key (stringsdict_entry_has_missing_variable)",
+            "en.stringsdict:10: error: Variable xyz does not exist in 'abc' but is used in the format key (stringsdict_entry_has_missing_variable)",
         ])
     }
 
     func testMissingVariableInRule() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "%#@def@"),
             rules: [
                 "def": StringsdictRule(
                     key: "def",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -48,13 +52,14 @@ class StringsdictEntryTests: XCTestCase {
         let problemReporter = ProblemReporter(log: false)
         entry.validateRuleVariables(path: "en.stringsdict", problemReporter: problemReporter)
         XCTAssertEqual(problemReporter.problems.map(\.messageForXcode), [
-            "en.stringsdict:0: error: Variable xyz does not exist in 'abc' but is used in 'def'.other (stringsdict_entry_has_missing_variable)",
+            "en.stringsdict:10: error: Variable xyz does not exist in 'abc' but is used in 'def'.other (stringsdict_entry_has_missing_variable)",
         ])
     }
 
     func testRuleExpansion_baseCase() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "abc"),
             rules: [:])
 
@@ -64,10 +69,12 @@ class StringsdictEntryTests: XCTestCase {
     func testRuleExpansion_oneLevel_oneAlternative() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "abc %#@def@"),
             rules: [
                 "def": StringsdictRule(
                     key: "def",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -81,10 +88,12 @@ class StringsdictEntryTests: XCTestCase {
     func testRuleExpansion_oneLevel_twoAlternatives() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "abc %#@def@"),
             rules: [
                 "def": StringsdictRule(
                     key: "def",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -99,10 +108,12 @@ class StringsdictEntryTests: XCTestCase {
     func testRuleExpansion_twoLevels_fourAlternatives() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "%#@a@ %#@n@"),
             rules: [
                 "a": StringsdictRule(
                     key: "a",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -111,6 +122,7 @@ class StringsdictEntryTests: XCTestCase {
                     ]),
                 "n": StringsdictRule(
                     key: "n",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -125,10 +137,12 @@ class StringsdictEntryTests: XCTestCase {
     func testGetCanonicalArgumentList_logsNoErrorsForValidEntry() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "%1$d %#@level1@"),
             rules: [
                 "level1": StringsdictRule(
                     key: "level1",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -137,6 +151,7 @@ class StringsdictEntryTests: XCTestCase {
                     ]),
                 "level2": StringsdictRule(
                     key: "level2",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -159,10 +174,12 @@ class StringsdictEntryTests: XCTestCase {
     func testGetCanonicalArgumentList_logsErrorForSpecifierMismatch() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "%1$d %#@level1@"),
             rules: [
                 "level1": StringsdictRule(
                     key: "level1",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -171,6 +188,7 @@ class StringsdictEntryTests: XCTestCase {
                     ]),
                 "level2": StringsdictRule(
                     key: "level2",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -181,8 +199,8 @@ class StringsdictEntryTests: XCTestCase {
         let problemReporter = ProblemReporter(log: false)
         let argList = entry.getCanonicalArgumentList(path: "abc", problemReporter: problemReporter)
         XCTAssertEqual(problemReporter.problems.map(\.messageForXcode), [
-            "abc:0: error: Two permutations of 'abc' contain different format specifiers at position 2. '%1$d %2$@ other %3$d' uses '@', and '%1$d %2$d %3$d' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)",
-            "abc:0: error: Two permutations of 'abc' contain different format specifiers at position 2. '%1$d %2$@ other %3$d' uses '@', and '%1$d %2$d %3$d other' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)",
+            "abc:10: error: Two permutations of 'abc' contain different format specifiers at position 2. '%1$d %2$@ other %3$d' uses '@', and '%1$d %2$d %3$d' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)",
+            "abc:10: error: Two permutations of 'abc' contain different format specifiers at position 2. '%1$d %2$@ other %3$d' uses '@', and '%1$d %2$d %3$d other' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)",
         ])
         XCTAssertEqual(
             argList,
@@ -197,10 +215,12 @@ class StringsdictEntryTests: XCTestCase {
     func testGetCanonicalArgumentList_logsErrorForUnusedArgument() {
         let entry = StringsdictEntry(
             key: "abc",
+            line: 10,
             formatKey: LexedStringsdictString(string: "%1$d %#@level1@"),
             rules: [
                 "level1": StringsdictRule(
                     key: "level1",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -209,6 +229,7 @@ class StringsdictEntryTests: XCTestCase {
                     ]),
                 "level2": StringsdictRule(
                     key: "level2",
+                    line: 10,
                     specType: "plural",
                     valueType: "d",
                     alternatives: [
@@ -219,7 +240,7 @@ class StringsdictEntryTests: XCTestCase {
         let problemReporter = ProblemReporter(log: false)
         let argList = entry.getCanonicalArgumentList(path: "abc", problemReporter: problemReporter)
         XCTAssertEqual(problemReporter.problems.map(\.messageForXcode), [
-            "abc:0: warning: No permutation of 'abc' use argument(s) at position 2 (stringsdict_entry_has_unused_arguments)",
+            "abc:10: warning: No permutation of 'abc' use argument(s) at position 2 (stringsdict_entry_has_unused_arguments)",
         ])
         XCTAssertEqual(
             argList,

--- a/Tests/LocheckCommandTests/ValidateStringsTests.swift
+++ b/Tests/LocheckCommandTests/ValidateStringsTests.swift
@@ -17,13 +17,13 @@ class ValidateStringsTests: XCTestCase {
                 LocalizedStringPair(
                     string: "\"present\" = \"present\";",
                     path: "abc",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationStrings: [
                 LocalizedStringPair(
                     string: "\"present\" = \"tneserp\";",
                     path: "def",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationLanguageName: "translation",
             problemReporter: problemReporter)
@@ -39,13 +39,13 @@ class ValidateStringsTests: XCTestCase {
                 LocalizedStringPair(
                     string: "\"present %d %@\" = \"present %d %@\";",
                     path: "abc",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationStrings: [
                 LocalizedStringPair(
                     string: "\"present %d %@\" = \"%d %@\";",
                     path: "def",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationLanguageName: "translation",
             problemReporter: problemReporter)
@@ -61,13 +61,13 @@ class ValidateStringsTests: XCTestCase {
                 LocalizedStringPair(
                     string: "\"present %d %@\" = \"present %d %@\";",
                     path: "abc",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationStrings: [
                 LocalizedStringPair(
                     string: "\"present %d %@\" = \"%@ %d tneserp\";", // specifiers swapped
                     path: "def",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationLanguageName: "translation",
             problemReporter: problemReporter)
@@ -88,13 +88,13 @@ class ValidateStringsTests: XCTestCase {
                 LocalizedStringPair(
                     string: "\"present %1$d %2$@\" = \"present %1$d %2$@\";",
                     path: "abc",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationStrings: [
                 LocalizedStringPair(
                     string: "\"present %1$d %2$@\" = \"tneserp %2$@ %1$d\";",
                     path: "def",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationLanguageName: "translation",
             problemReporter: problemReporter)
@@ -110,7 +110,7 @@ class ValidateStringsTests: XCTestCase {
                 LocalizedStringPair(
                     string: "\"present\" = \"present\";",
                     path: "abc",
-                    line: nil)!,
+                    line: 0)!,
                 LocalizedStringPair(
                     string: "\"missing\" = \"missing\";",
                     path: "abc",
@@ -120,7 +120,7 @@ class ValidateStringsTests: XCTestCase {
                 LocalizedStringPair(
                     string: "\"present\" = \"tneserp\";",
                     path: "def",
-                    line: nil)!,
+                    line: 0)!,
             ],
             translationLanguageName: "trnsltn",
             problemReporter: problemReporter)

--- a/Tests/LocheckCommandTests/parseAndValidateAndroidStringsTests.swift
+++ b/Tests/LocheckCommandTests/parseAndValidateAndroidStringsTests.swift
@@ -25,7 +25,7 @@ class ParseAndValidateAndroidStringsTests: XCTestCase {
             translationLanguageName: "demo",
             problemReporter: problemReporter)
 
-        XCTAssertEqual(problemReporter.problems.count, 2)
+        XCTAssertEqual(problemReporter.problems.count, 5)
         let problems = problemReporter.problems.map(\.problem)
         CastAndAssertEqual(problems[0], KeyMissingFromTranslation(key: "missing_from_translation", language: "demo"))
         CastAndAssertEqual(problems[1], KeyMissingFromBase(key: "missing_from_base"))

--- a/Tests/LocheckCommandTests/parseAndValidateAndroidStringsTests.swift
+++ b/Tests/LocheckCommandTests/parseAndValidateAndroidStringsTests.swift
@@ -26,7 +26,8 @@ class ParseAndValidateAndroidStringsTests: XCTestCase {
             problemReporter: problemReporter)
 
         XCTAssertEqual(problemReporter.problems.count, 2)
-        XCTAssertEqual(problemReporter.problems[0].problem as? KeyMissingFromTranslation, KeyMissingFromTranslation(key: "missing_from_translation", language: "demo"))
-        XCTAssertEqual(problemReporter.problems[1].problem as? KeyMissingFromBase, KeyMissingFromBase(key: "missing_from_base"))
+        let problems = problemReporter.problems.map(\.problem)
+        CastAndAssertEqual(problems[0], KeyMissingFromTranslation(key: "missing_from_translation", language: "demo"))
+        CastAndAssertEqual(problems[1], KeyMissingFromBase(key: "missing_from_base"))
     }
 }

--- a/Tests/LocheckCommandTests/parseAndValidateAndroidStringsTests.swift
+++ b/Tests/LocheckCommandTests/parseAndValidateAndroidStringsTests.swift
@@ -1,6 +1,6 @@
 //
 //  parseAndValidateAndroidStringsTests.swift
-//  
+//
 //
 //  Created by Steve Landey on 9/1/21.
 //

--- a/Tests/LocheckCommandTests/parseAndValidateStringsdictTests.swift
+++ b/Tests/LocheckCommandTests/parseAndValidateStringsdictTests.swift
@@ -27,27 +27,27 @@ class ParseAndValidateStringsdictTests: XCTestCase {
         XCTAssertEqual(problemReporter.problems.count, 8)
         XCTAssertEqual(
             problemReporter.problems[0].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Base.stringsdict:0: warning: '%d/%d Completed' is missing from Demo_Translation (key_missing_from_translation)")
+            "\(packageRootPath)/Examples/Demo_Base.stringsdict:22: warning: '%d/%d Completed' is missing from Demo_Translation (key_missing_from_translation)")
         XCTAssertEqual(
             problemReporter.problems[1].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Base.stringsdict:0: warning: 'missing from translation' is missing from Demo_Translation (key_missing_from_translation)")
+            "\(packageRootPath)/Examples/Demo_Base.stringsdict:63: warning: 'missing from translation' is missing from Demo_Translation (key_missing_from_translation)")
         XCTAssertEqual(
             problemReporter.problems[2].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:0: warning: 'missing from base' is missing from the base translation (key_missing_from_base)")
+            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:22: warning: 'missing from base' is missing from the base translation (key_missing_from_base)")
         XCTAssertEqual(
             problemReporter.problems[3].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:0: ignored: Argument 2 in permutation '%2$lu jours toutes les %d semaines of 'Every %d week(s) on %lu days' has an implicit position. Use an explicit position for safety. (stringsdict_entry_has_implicit_position)")
+            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:6: ignored: Argument 2 in permutation '%2$lu jours toutes les %d semaines of 'Every %d week(s) on %lu days' has an implicit position. Use an explicit position for safety. (stringsdict_entry_has_implicit_position)")
         XCTAssertEqual(
             problemReporter.problems[4].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:0: error: Two permutations of 'Every %d week(s) on %lu days' contain different format specifiers at position 2. '%2$lu jours toutes les %d semaines' uses 'lu', and '%2$lu jours toutes les %d semaines' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)")
+            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:6: error: Two permutations of 'Every %d week(s) on %lu days' contain different format specifiers at position 2. '%2$lu jours toutes les %d semaines' uses 'lu', and '%2$lu jours toutes les %d semaines' uses 'd'. (stringsdict_entry_permutations_have_conflicting_specifiers)")
         XCTAssertEqual(
             problemReporter.problems[5].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:0: warning: No permutation of 'Every %d week(s) on %lu days' use argument(s) at position 1 (stringsdict_entry_has_unused_arguments)")
+            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:6: warning: No permutation of 'Every %d week(s) on %lu days' use argument(s) at position 1 (stringsdict_entry_has_unused_arguments)")
         XCTAssertEqual(
             problemReporter.problems[6].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Base.stringsdict:0: ignored: Argument 1 in permutation 'Every %d weeks on %2$lu days of 'Every %d week(s) on %lu days' has an implicit position. Use an explicit position for safety. (stringsdict_entry_has_implicit_position)")
+            "\(packageRootPath)/Examples/Demo_Base.stringsdict:6: ignored: Argument 1 in permutation 'Every %d weeks on %2$lu days of 'Every %d week(s) on %lu days' has an implicit position. Use an explicit position for safety. (stringsdict_entry_has_implicit_position)")
         XCTAssertEqual(
             problemReporter.problems[7].messageForXcode,
-            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:0: warning: 'Every %d week(s) on %lu days' does not use argument 1 (stringsdict_entry_missing_argument)")
+            "\(packageRootPath)/Examples/Demo_Translation.stringsdict:6: warning: 'Every %d week(s) on %lu days' does not use argument 1 (stringsdict_entry_missing_argument)")
     }
 }


### PR DESCRIPTION
- [X] Add `--ignore` argument to disable rules
- [X] Parse CDATA
- [x] Remember line numbers in XML
- [x] Many additional Android validation rules
- [x] `locheck discovervalues` should work on `/res/` directories
- [x] Rename `locheck discover` to `locheck discoverlproj`

I ran `locheck discovervalues` on our Android codebase and verified with our Android team that the errors and warnings are valid.

Once this PR is landed, I'm ready to cut release `0.9`. We can go to 1.0 after a couple months.

When you finish with this, please also look at #12.