### PR TITLE
Be less strict about which files exist

### DIFF
--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -157,7 +157,7 @@ struct Stringsdict: ParsableCommand {
             let baseFile = stringsdictFiles[0]
             let translationFiles = stringsdictFiles.dropFirst()
             // Just do what we can with the base language, i.e. validate plurals
-            if translationFiles.isEmpty, let stringsdictFile = LocheckLogic.Stringsdict(
+            if translationFiles.isEmpty, let stringsdictFile = StringsdictFile(
                 path: baseFile.argument,
                 problemReporter: problemReporter) {
                 stringsdictFile.entries.forEach { _ = $0.getCanonicalArgumentList(problemReporter: problemReporter) }

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -199,7 +199,9 @@ struct Lproj: ParsableCommand {
     func run() {
         let baseFile = lprojFiles[0]
         let translationFiles = lprojFiles.dropFirst()
-        print("Validating \(translationFiles.count) lproj files against \(try! Folder(path: baseFile.argument).name)")
+        if !translationFiles.isEmpty {
+            print("Validating \(translationFiles.count) lproj files against \(try! Folder(path: baseFile.argument).name)")
+        }
 
         withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
             // Same as in DiscoverLproj command below
@@ -245,17 +247,10 @@ struct DiscoverLproj: ParsableCommand {
         for directory in directories {
             try directory.validate()
 
-            var hasBase = false
-            // It's OK if there are no translations, we can still do stuff
-
-            for folder in try! Folder(path: directory.argument).subfolders where folder.extension == "lproj" {
-                if folder.name == "\(base).lproj" {
-                    hasBase = true
-                }
-            }
+            let hasBase = try! Folder(path: directory.argument).subfolders.contains { $0.name == "\(base).lproj" }
 
             if !hasBase {
-                throw ValidationError("Can't find \(base).lproj or values/ directory in \(directory.argument)")
+                throw ValidationError("Can't find \(base).lproj in \(directory.argument). Do you need to specify --base?")
             }
         }
     }

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -200,7 +200,8 @@ struct Lproj: ParsableCommand {
         let baseFile = lprojFiles[0]
         let translationFiles = lprojFiles.dropFirst()
         if !translationFiles.isEmpty {
-            print("Validating \(translationFiles.count) lproj files against \(try! Folder(path: baseFile.argument).name)")
+            print(
+                "Validating \(translationFiles.count) lproj files against \(try! Folder(path: baseFile.argument).name)")
         }
 
         withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
@@ -250,7 +251,8 @@ struct DiscoverLproj: ParsableCommand {
             let hasBase = try! Folder(path: directory.argument).subfolders.contains { $0.name == "\(base).lproj" }
 
             if !hasBase {
-                throw ValidationError("Can't find \(base).lproj in \(directory.argument). Do you need to specify --base?")
+                throw ValidationError(
+                    "Can't find \(base).lproj in \(directory.argument). Do you need to specify --base?")
             }
         }
     }

--- a/Sources/LocheckLogic/Types/FormatArgument.swift
+++ b/Sources/LocheckLogic/Types/FormatArgument.swift
@@ -10,7 +10,7 @@ import Foundation
 /// The contents of one "%d" or "%2$@" argument. (These would be
 /// `FormatArgument(specifier: "d", position: <automatic>)` and
 /// `FormatArgument(specifier: "@", position: 2)`, respectively.)
-struct FormatArgument: Equatable, Hashable {
+public struct FormatArgument: Equatable, Hashable {
     let specifier: String
     let position: Int
     let isPositionExplicit: Bool

--- a/Sources/LocheckLogic/Types/LprojFiles.swift
+++ b/Sources/LocheckLogic/Types/LprojFiles.swift
@@ -34,4 +34,11 @@ public struct LprojFiles {
         self.strings = strings
         self.stringsdict = stringsdict
     }
+
+    public func validateInternally(problemReporter: ProblemReporter) {
+        stringsdict
+            .compactMap { LocheckLogic.Stringsdict(path: $0.path, problemReporter: problemReporter) }
+            .flatMap { $0.entries }
+            .forEach { _ = $0.getCanonicalArgumentList(problemReporter: problemReporter) }
+    }
 }

--- a/Sources/LocheckLogic/Types/LprojFiles.swift
+++ b/Sources/LocheckLogic/Types/LprojFiles.swift
@@ -37,7 +37,7 @@ public struct LprojFiles {
 
     public func validateInternally(problemReporter: ProblemReporter) {
         stringsdict
-            .compactMap { LocheckLogic.Stringsdict(path: $0.path, problemReporter: problemReporter) }
+            .compactMap { StringsdictFile(path: $0.path, problemReporter: problemReporter) }
             .flatMap { $0.entries }
             .forEach { _ = $0.getCanonicalArgumentList(problemReporter: problemReporter) }
     }

--- a/Sources/LocheckLogic/Types/LprojFiles.swift
+++ b/Sources/LocheckLogic/Types/LprojFiles.swift
@@ -38,7 +38,7 @@ public struct LprojFiles {
     public func validateInternally(problemReporter: ProblemReporter) {
         stringsdict
             .compactMap { StringsdictFile(path: $0.path, problemReporter: problemReporter) }
-            .flatMap { $0.entries }
+            .flatMap(\.entries)
             .forEach { _ = $0.getCanonicalArgumentList(problemReporter: problemReporter) }
     }
 }

--- a/Sources/LocheckLogic/Types/Stringsdict.swift
+++ b/Sources/LocheckLogic/Types/Stringsdict.swift
@@ -27,16 +27,16 @@ import SwiftyXMLParser
         other: "%d cool motorcycles"                        // another 'alternative'
  ```
  */
-struct Stringsdict: Equatable {
-    let path: String
-    let entries: [StringsdictEntry]
+public struct Stringsdict: Equatable {
+    public let path: String
+    public let entries: [StringsdictEntry]
 
     init(path: String, entries: [StringsdictEntry]) {
         self.path = path
         self.entries = entries
     }
 
-    init?(path: String, problemReporter: ProblemReporter) {
+    public init?(path: String, problemReporter: ProblemReporter) {
         self.path = path
         guard let xml = parseXML(file: try! File(path: path), problemReporter: problemReporter) else {
             return nil

--- a/Sources/LocheckLogic/Types/StringsdictFile.swift
+++ b/Sources/LocheckLogic/Types/StringsdictFile.swift
@@ -27,7 +27,7 @@ import SwiftyXMLParser
         other: "%d cool motorcycles"                        // another 'alternative'
  ```
  */
-public struct Stringsdict: Equatable {
+public struct StringsdictFile: Equatable {
     public let path: String
     public let entries: [StringsdictEntry]
 

--- a/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
@@ -43,10 +43,9 @@ func validateStringsdict(
 
     let baseArgLists = baseStringsdict.entries.lo_makeDictionary(
         makeKey: \.key,
-        makeValue: { $0.getCanonicalArgumentList(path: baseStringsdict.path, problemReporter: problemReporter) })
+        makeValue: { $0.getCanonicalArgumentList(problemReporter: problemReporter) })
     for translation in translationStringsdict.entries {
         let translationArgs = translation.getCanonicalArgumentList(
-            path: translationStringsdict.path,
             problemReporter: problemReporter)
         guard let baseArgs = baseArgLists[translation.key] else {
             continue // error already logged above

--- a/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateStringsdict.swift
@@ -13,10 +13,10 @@ public func parseAndValidateStringsdict(
     translation translationFile: File,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
-    guard let base = Stringsdict(path: baseFile.path, problemReporter: problemReporter) else {
+    guard let base = StringsdictFile(path: baseFile.path, problemReporter: problemReporter) else {
         return
     }
-    guard let translation = Stringsdict(path: translationFile.path, problemReporter: problemReporter) else {
+    guard let translation = StringsdictFile(path: translationFile.path, problemReporter: problemReporter) else {
         return
     }
     validateStringsdict(
@@ -27,8 +27,8 @@ public func parseAndValidateStringsdict(
 }
 
 func validateStringsdict(
-    base baseStringsdict: Stringsdict,
-    translation translationStringsdict: Stringsdict,
+    base baseStringsdict: StringsdictFile,
+    translation translationStringsdict: StringsdictFile,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
     validateKeyPresence(


### PR DESCRIPTION
1. Android `values` directories may omit `strings.xml` if they are not the primary language. (Fix #16)
2. You may pass only one lproj/stringsdict/strings.xml/values file and still have validation happen. (Fix #13)

Incidentally renames `Stringsdict` to `StringsdictFile` to match other types.