### PR TITLE
Various improvements to support checking Wikipedia's iOS app

### DIFF
--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -44,7 +44,8 @@ private func withProblemReporter(ignore: [String], ignoreWarnings: Bool, _ block
 
 private let ignoreHelpText: ArgumentHelp = "Ignore a rule completely."
 
-private let ignoreMissingHelpText: ArgumentHelp = "Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'."
+private let ignoreMissingHelpText: ArgumentHelp =
+    "Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'."
 
 private let ignoreWarningsHelpText: ArgumentHelp = "Ignore all warning-level issues."
 
@@ -52,8 +53,9 @@ private protocol HasIgnoreWithShorthand {
     var ignore: [String] { get }
     var ignoreMissing: Bool { get }
 }
-extension HasIgnoreWithShorthand {
-    fileprivate var ignoreWithShorthand: [String] {
+
+private extension HasIgnoreWithShorthand {
+    var ignoreWithShorthand: [String] {
         ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
     }
 }

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -32,8 +32,8 @@ struct Locheck: ParsableCommand {
         ])
 }
 
-private func withProblemReporter(ignore: [String], _ block: (ProblemReporter) -> Void) {
-    let problemReporter = ProblemReporter(ignoredProblemIdentifiers: ignore)
+private func withProblemReporter(ignore: [String], ignoreWarnings: Bool, _ block: (ProblemReporter) -> Void) {
+    let problemReporter = ProblemReporter(ignoredProblemIdentifiers: ignore, ignoreWarnings: ignoreWarnings)
     block(problemReporter)
     if problemReporter.hasError {
         print("Errors found")
@@ -42,36 +42,45 @@ private func withProblemReporter(ignore: [String], _ block: (ProblemReporter) ->
     print("Finished validating")
 }
 
-private let ignoreHelpText: ArgumentHelp =
-    "Ignore a rule completely."
+private let ignoreHelpText: ArgumentHelp = "Ignore a rule completely."
 
-private let ignoreMissingHelpText: ArgumentHelp =
-    "Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'."
+private let ignoreMissingHelpText: ArgumentHelp = "Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'."
 
-struct XCStrings: ParsableCommand {
+private let ignoreWarningsHelpText: ArgumentHelp = "Ignore all warning-level issues."
+
+private protocol HasIgnoreWithShorthand {
+    var ignore: [String] { get }
+    var ignoreMissing: Bool { get }
+}
+extension HasIgnoreWithShorthand {
+    fileprivate var ignoreWithShorthand: [String] {
+        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
+    }
+}
+
+struct XCStrings: HasIgnoreWithShorthand, ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "xcstrings",
         abstract: "Directly compare .strings files")
 
     @Argument(help: "A list of .strings files, starting with the primary language")
-    private var stringsFiles: [FileArg]
+    private var stringsFiles: [FileArg] = []
 
     @Option(help: ignoreHelpText)
-    private var ignore = [String]()
+    fileprivate var ignore = [String]()
 
     @Flag(help: ignoreMissingHelpText)
-    private var ignoreMissing = false
+    fileprivate var ignoreMissing = false
 
-    private var ignoreWithShorthand: [String] {
-        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
-    }
+    @Flag(help: ignoreWarningsHelpText)
+    fileprivate var ignoreWarnings = false
 
     func validate() throws {
         try stringsFiles.forEach { try $0.validate(ext: "strings") }
     }
 
     func run() {
-        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
             let base = stringsFiles[0]
             let translationFiles = stringsFiles.dropFirst()
             for file in translationFiles {
@@ -87,7 +96,7 @@ struct XCStrings: ParsableCommand {
     }
 }
 
-struct AndroidStrings: ParsableCommand {
+struct AndroidStrings: HasIgnoreWithShorthand, ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "androidstrings",
         abstract: "Directly compare strings.xml files")
@@ -96,21 +105,20 @@ struct AndroidStrings: ParsableCommand {
     private var stringsFiles: [FileArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore = [String]()
+    fileprivate var ignore = [String]()
 
     @Flag(help: ignoreMissingHelpText)
-    private var ignoreMissing = false
+    fileprivate var ignoreMissing = false
 
-    private var ignoreWithShorthand: [String] {
-        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
-    }
+    @Flag(help: ignoreWarningsHelpText)
+    fileprivate var ignoreWarnings = false
 
     func validate() throws {
         try stringsFiles.forEach { try $0.validate(ext: "xml") }
     }
 
     func run() {
-        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
             let baseFile = stringsFiles[0]
             let translationFiles = stringsFiles.dropFirst()
             if translationFiles.isEmpty {
@@ -134,7 +142,7 @@ struct AndroidStrings: ParsableCommand {
     }
 }
 
-struct Stringsdict: ParsableCommand {
+struct Stringsdict: HasIgnoreWithShorthand, ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Directly compare .stringsdict files")
 
@@ -142,21 +150,20 @@ struct Stringsdict: ParsableCommand {
     private var stringsdictFiles: [FileArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore = [String]()
+    fileprivate var ignore = [String]()
 
     @Flag(help: ignoreMissingHelpText)
-    private var ignoreMissing = false
+    fileprivate var ignoreMissing = false
 
-    private var ignoreWithShorthand: [String] {
-        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
-    }
+    @Flag(help: ignoreWarningsHelpText)
+    fileprivate var ignoreWarnings = false
 
     func validate() throws {
         try stringsdictFiles.forEach { try $0.validate(ext: "stringsdict") }
     }
 
     func run() {
-        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
             let baseFile = stringsdictFiles[0]
             let translationFiles = stringsdictFiles.dropFirst()
             // Just do what we can with the base language, i.e. validate plurals
@@ -178,7 +185,7 @@ struct Stringsdict: ParsableCommand {
     }
 }
 
-struct Lproj: ParsableCommand {
+struct Lproj: HasIgnoreWithShorthand, ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Compare the contents of multiple .lproj files")
 
@@ -186,14 +193,13 @@ struct Lproj: ParsableCommand {
     private var lprojFiles: [DirectoryArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore = [String]()
+    fileprivate var ignore = [String]()
 
     @Flag(help: ignoreMissingHelpText)
-    private var ignoreMissing = false
+    fileprivate var ignoreMissing = false
 
-    private var ignoreWithShorthand: [String] {
-        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
-    }
+    @Flag(help: ignoreWarningsHelpText)
+    fileprivate var ignoreWarnings = false
 
     func validate() throws {
         try lprojFiles.forEach { try $0.validate(ext: "lproj") }
@@ -207,7 +213,7 @@ struct Lproj: ParsableCommand {
                 "Validating \(translationFiles.count) lproj files against \(try! Folder(path: baseFile.argument).name)")
         }
 
-        withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
+        withProblemReporter(ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
             // Same as in DiscoverLproj command below
             if translationFiles.isEmpty {
                 // Just do what we can with the base language, i.e. validate plurals
@@ -225,7 +231,7 @@ struct Lproj: ParsableCommand {
     }
 }
 
-struct DiscoverLproj: ParsableCommand {
+struct DiscoverLproj: HasIgnoreWithShorthand, ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "discoverlproj",
         abstract: "Automatically find .lproj files within a directory and compare them")
@@ -238,14 +244,13 @@ struct DiscoverLproj: ParsableCommand {
     private var directories: [DirectoryArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore = [String]()
+    fileprivate var ignore = [String]()
 
     @Flag(help: ignoreMissingHelpText)
-    private var ignoreMissing = false
+    fileprivate var ignoreMissing = false
 
-    private var ignoreWithShorthand: [String] {
-        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
-    }
+    @Flag(help: ignoreWarningsHelpText)
+    fileprivate var ignoreWarnings = false
 
     func validate() throws {
         for directory in directories {
@@ -282,7 +287,7 @@ struct DiscoverLproj: ParsableCommand {
             print("Source of truth: \(baseLproj.path)")
             print("Translations to check: \(translationLproj.count)")
 
-            withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
+            withProblemReporter(ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
                 // Same as in Lproj command above
                 if translationLproj.isEmpty {
                     // Just do what we can with the base language, i.e. validate plurals
@@ -298,7 +303,7 @@ struct DiscoverLproj: ParsableCommand {
     }
 }
 
-struct DiscoverValues: ParsableCommand {
+struct DiscoverValues: HasIgnoreWithShorthand, ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "discovervalues",
         abstract: "Automatically find values/ directories files within a directory and compare their strings.xml files")
@@ -307,14 +312,13 @@ struct DiscoverValues: ParsableCommand {
     private var directories: [DirectoryArg]
 
     @Option(help: ignoreHelpText)
-    private var ignore = [String]()
+    fileprivate var ignore = [String]()
 
     @Flag(help: ignoreMissingHelpText)
-    private var ignoreMissing = false
+    fileprivate var ignoreMissing = false
 
-    private var ignoreWithShorthand: [String] {
-        ignore + (ignoreMissing ? ["key_missing_from_base", "key_missing_from_translation"] : [])
-    }
+    @Flag(help: ignoreWarningsHelpText)
+    fileprivate var ignoreWarnings = false
 
     func validate() throws {
         for directory in directories {
@@ -362,7 +366,7 @@ struct DiscoverValues: ParsableCommand {
             print("Source of truth: \(primaryValues.path)")
             print("Translations to check: \(translationValues.count)")
 
-            withProblemReporter(ignore: ignoreWithShorthand) { problemReporter in
+            withProblemReporter(ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
                 for translation in translationValues {
                     parseAndValidateAndroidStrings(
                         base: primaryValues,

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -77,8 +77,8 @@ struct XCStrings: ParsableCommand {
             for file in translationFiles {
                 let translationFile = try! File(path: file.argument)
                 parseAndValidateXCStrings(
-                    base: try! File(path: base.argument),
-                    translation: translationFile,
+                    base: [try! File(path: base.argument)],
+                    translation: [translationFile],
                     translationLanguageName: translationFile.nameExcludingExtension,
                     problemReporter: problemReporter)
             }
@@ -262,7 +262,7 @@ struct DiscoverLproj: ParsableCommand {
 
     func run() {
         for directory in directories {
-            print("Discovering .lproj files in \(directory.argument)")
+            print("Discovering .lproj files in \(directory.argument) with \(base) as the base")
 
             var maybePrimaryLproj: LprojFiles!
             var translationLproj = [LprojFiles]()

--- a/Sources/LocheckLogic/Extensions/File+locheck.swift
+++ b/Sources/LocheckLogic/Extensions/File+locheck.swift
@@ -9,7 +9,17 @@ import Files
 import Foundation
 
 extension File {
-    var lo_lines: [String] {
-        try! readAsString().split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map { String($0) }
+    func lo_getLines(problemReporter: ProblemReporter) -> [String]? {
+        do {
+            return try readAsString()
+                .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+                .map { String($0) }
+        } catch {
+            problemReporter.report(
+                SwiftError(error: error),
+                path: path,
+                lineNumber: 0)
+            return nil
+        }
     }
 }

--- a/Sources/LocheckLogic/Extensions/File+locheck.swift
+++ b/Sources/LocheckLogic/Extensions/File+locheck.swift
@@ -14,9 +14,29 @@ extension File {
             return try readAsString()
                 .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
                 .map { String($0) }
+        } catch is FilesError<Files.ReadErrorReason> {
+            // try UTF-16 below
         } catch {
             problemReporter.report(
-                SwiftError(error: error),
+                SwiftError(description: error.localizedDescription),
+                path: path,
+                lineNumber: 0)
+            return nil
+        }
+
+        do {
+            return try readAsString(encodedAs: .utf16)
+                .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+                .map { String($0) }
+        } catch is FilesError<Files.ReadErrorReason> {
+            problemReporter.report(
+                SwiftError(description: "File is not encoded as UTF-8 or UTF-16"),
+                path: path,
+                lineNumber: 0)
+            return nil
+        } catch {
+            problemReporter.report(
+                SwiftError(description: error.localizedDescription),
                 path: path,
                 lineNumber: 0)
             return nil

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -57,14 +57,16 @@ public class ProblemReporter {
 
     public var log: Bool
     public let ignoredProblemIdentifiers: Set<String>
+    public let ignoreWarnings: Bool
 
-    public init(log: Bool = true, ignoredProblemIdentifiers: [String] = []) {
+    public init(log: Bool = true, ignoredProblemIdentifiers: [String] = [], ignoreWarnings: Bool = false) {
         self.log = log
         self.ignoredProblemIdentifiers = Set(ignoredProblemIdentifiers)
+        self.ignoreWarnings = ignoreWarnings
     }
 
     public func report(_ problem: Problem, path: String, lineNumber: Int) {
-        guard !ignoredProblemIdentifiers.contains(problem.kindIdentifier) else { return }
+        guard !ignoredProblemIdentifiers.contains(problem.kindIdentifier) && (!ignoreWarnings || problem.severity == .error) else { return }
         let localProblem = LocalProblem(path: path, lineNumber: lineNumber, problem: problem)
         problems.append(localProblem)
 

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -76,8 +76,7 @@ public class ProblemReporter {
     public func printSummary() {
         guard problems.contains(where: { $0.problem.severity != .ignored }) else { return }
         var problemsByFile = [String: [LocalProblem]]()
-        for localProblem in problems
-            where localProblem.problem as? SummarizableProblem != nil && localProblem.problem.severity != .ignored {
+        for localProblem in problems where localProblem.problem.severity != .ignored {
             if problemsByFile[localProblem.path] == nil {
                 problemsByFile[localProblem.path] = []
             }
@@ -88,12 +87,17 @@ public class ProblemReporter {
 
         for path in problemsByFile.keys.sorted() {
             print(path)
-            let problems = problemsByFile[path]!.map { $0.problem as! SummarizableProblem }
-            let keys = Set(problems.map(\.key))
+
+            for problem in problemsByFile[path]!.filter({ $0.problem as? SummarizableProblem == nil }) {
+                print("  \(problem.problem.severity.rawValue.uppercased()): \(problem.problem.message) (\(problem.problem.kindIdentifier))")
+            }
+
+            let summarizableProblems = problemsByFile[path]!.compactMap { $0.problem as? SummarizableProblem }
+            let keys = Set(summarizableProblems.map(\.key))
             for key in keys.sorted() {
                 print("  \(key):")
-                for problem in problems.filter({ $0.key == key }) {
-                    print("    \(problem.severity.rawValue.uppercased()): \(problem.message)")
+                for problem in summarizableProblems.filter({ $0.key == key }) {
+                    print("    \(problem.severity.rawValue.uppercased()): \(problem.message) (\(problem.kindIdentifier))")
                 }
             }
         }

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -66,7 +66,8 @@ public class ProblemReporter {
     }
 
     public func report(_ problem: Problem, path: String, lineNumber: Int) {
-        guard !ignoredProblemIdentifiers.contains(problem.kindIdentifier) && (!ignoreWarnings || problem.severity == .error) else { return }
+        guard !ignoredProblemIdentifiers
+            .contains(problem.kindIdentifier) && (!ignoreWarnings || problem.severity == .error) else { return }
         let localProblem = LocalProblem(path: path, lineNumber: lineNumber, problem: problem)
         problems.append(localProblem)
 
@@ -91,7 +92,8 @@ public class ProblemReporter {
             print(path)
 
             for problem in problemsByFile[path]!.filter({ $0.problem as? SummarizableProblem == nil }) {
-                print("  \(problem.problem.severity.rawValue.uppercased()): \(problem.problem.message) (\(problem.problem.kindIdentifier))")
+                print(
+                    "  \(problem.problem.severity.rawValue.uppercased()): \(problem.problem.message) (\(problem.problem.kindIdentifier))")
             }
 
             let summarizableProblems = problemsByFile[path]!.compactMap { $0.problem as? SummarizableProblem }
@@ -99,7 +101,8 @@ public class ProblemReporter {
             for key in keys.sorted() {
                 print("  \(key):")
                 for problem in summarizableProblems.filter({ $0.key == key }) {
-                    print("    \(problem.severity.rawValue.uppercased()): \(problem.message) (\(problem.kindIdentifier))")
+                    print(
+                        "    \(problem.severity.rawValue.uppercased()): \(problem.message) (\(problem.kindIdentifier))")
                 }
             }
         }

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -55,11 +55,18 @@ public class ProblemReporter {
     private var standardError = StderrOutputStream()
     public private(set) var problems = [LocalProblem]()
 
+    /// Path prefix for all problems. Used to remove the prefix from the summary for readability.
+    public let root: String
     public var log: Bool
     public let ignoredProblemIdentifiers: Set<String>
     public let ignoreWarnings: Bool
 
-    public init(log: Bool = true, ignoredProblemIdentifiers: [String] = [], ignoreWarnings: Bool = false) {
+    public init(
+        root: String = "",
+        log: Bool = true,
+        ignoredProblemIdentifiers: [String] = [],
+        ignoreWarnings: Bool = false) {
+        self.root = root
         self.log = log
         self.ignoredProblemIdentifiers = Set(ignoredProblemIdentifiers)
         self.ignoreWarnings = ignoreWarnings
@@ -89,7 +96,14 @@ public class ProblemReporter {
         print("\nSummary:")
 
         for path in problemsByFile.keys.sorted() {
-            print(path)
+            var pathToPrint = path
+            if path.hasPrefix(root) {
+                pathToPrint = String(pathToPrint.dropFirst(root.count))
+            }
+            if path.hasPrefix("/") {
+                pathToPrint = String(pathToPrint.dropFirst())
+            }
+            print(pathToPrint)
 
             for problem in problemsByFile[path]!.filter({ $0.problem as? SummarizableProblem == nil }) {
                 print(

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -100,7 +100,7 @@ public class ProblemReporter {
             if path.hasPrefix(root) {
                 pathToPrint = String(pathToPrint.dropFirst(root.count))
             }
-            if path.hasPrefix("/") {
+            if pathToPrint.hasPrefix("/") {
                 pathToPrint = String(pathToPrint.dropFirst())
             }
             print(pathToPrint)

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -15,13 +15,22 @@ protocol StringsProblem: SummarizableProblem {
     var key: String { get }
 }
 
-struct CDATACannotBeDecoded: Problem, Equatable {
+struct CDATACannotBeDecoded: Problem, Equatable, SummarizableProblem {
     var kindIdentifier: String { "cdata_cannot_be_decoded" }
     var uniquifyingInformation: String { "\(key)" }
     var severity: Severity { .error }
     let key: String
 
     var message: String { "'\(key)' has CDATA that cannot be decoded as UTF-8" }
+}
+
+struct SwiftError: Problem {
+    var kindIdentifier: String { "swift_error" }
+    var uniquifyingInformation: String { error.localizedDescription }
+    var severity: Severity { .error }
+    let error: Error
+
+    var message: String { error.localizedDescription }
 }
 
 struct DuplicateEntries: Problem, Equatable {

--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -26,11 +26,11 @@ struct CDATACannotBeDecoded: Problem, Equatable, SummarizableProblem {
 
 struct SwiftError: Problem {
     var kindIdentifier: String { "swift_error" }
-    var uniquifyingInformation: String { error.localizedDescription }
+    var uniquifyingInformation: String { description }
     var severity: Severity { .error }
-    let error: Error
+    let description: String
 
-    var message: String { error.localizedDescription }
+    var message: String { description }
 }
 
 struct DuplicateEntries: Problem, Equatable {

--- a/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
@@ -24,7 +24,8 @@ public func parseAndValidateXCStrings(
                     LocalizedStringPair(
                         string: $0.1,
                         path: file.path,
-                        line: $0.0 + 1)
+                        line: $0.0 + 1,
+                        baseStringMap: baseStringMap)
                 } ?? []
         }
     }

--- a/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
@@ -18,7 +18,8 @@ public func parseAndValidateXCStrings(
     problemReporter: ProblemReporter) {
     problemReporter.logInfo("Validating \(translation.path) against \(base.path)")
 
-    let baseStrings = base.lo_lines.enumerated()
+    guard let baseLines = base.lo_getLines(problemReporter: problemReporter) else { return }
+    let baseStrings = baseLines.enumerated()
         .compactMap {
             LocalizedStringPair(
                 string: $0.1,
@@ -27,7 +28,7 @@ public func parseAndValidateXCStrings(
         }
 
     var baseStringMap = [String: FormatString]()
-    for (i, line) in base.lo_lines.enumerated() {
+    for (i, line) in baseLines.enumerated() {
         guard let basePair = LocalizedStringPair(
             string: line,
             path: base.path,
@@ -38,9 +39,10 @@ public func parseAndValidateXCStrings(
         baseStringMap[basePair.base.string] = basePair.translation
     }
 
+    guard let translationLines = translation.lo_getLines(problemReporter: problemReporter) else { return }
     validateStrings(
         baseStrings: baseStrings,
-        translationStrings: translation.lo_lines.enumerated().compactMap {
+        translationStrings: translationLines.enumerated().compactMap {
             let p = LocalizedStringPair(
                 string: $0.1,
                 path: translation.path,

--- a/Sources/LocheckLogic/Validators/validateLproj.swift
+++ b/Sources/LocheckLogic/Validators/validateLproj.swift
@@ -12,22 +12,11 @@ import Foundation
  Directly compare `.strings` files with the same name across two `.lproj` files
  */
 public func validateLproj(base: LprojFiles, translation: LprojFiles, problemReporter: ProblemReporter) {
-    for stringsFile in base.strings {
-        guard let translationStringsFile = translation.strings.first(where: { $0.name == stringsFile.name }) else {
-            problemReporter.report(
-                LprojFileMissingFromTranslation(
-                    key: stringsFile.name,
-                    language: translation.name),
-                path: stringsFile.path,
-                lineNumber: 0)
-            continue
-        }
-        parseAndValidateXCStrings(
-            base: stringsFile,
-            translation: translationStringsFile,
-            translationLanguageName: translation.name,
-            problemReporter: problemReporter)
-    }
+    parseAndValidateXCStrings(
+        base: base.strings,
+        translation: translation.strings,
+        translationLanguageName: translation.name,
+        problemReporter: problemReporter)
 
     for baseStringsdictFile in base.stringsdict {
         guard let translationStringsdictFile = translation.stringsdict

--- a/Tests/LocheckCommandTests/ExecutableTests.swift
+++ b/Tests/LocheckCommandTests/ExecutableTests.swift
@@ -52,22 +52,21 @@ class ExecutableTests: XCTestCase {
 
         print(stdout!)
         XCTAssertEqual(stdout!, """
-        Validating Examples/Demo_Translation.strings against Examples/Demo_Base.strings
 
         Summary:
         Examples/Demo_Base.strings
           missing:
-            WARNING: 'missing' is missing from Demo_Translation
+            WARNING: 'missing' is missing from Demo_Translation (key_missing_from_translation)
         Examples/Demo_Translation.strings
           bad pos %ld %@:
-            WARNING: 'bad pos %ld %@' does not include argument(s) at 1
-            WARNING: Some arguments appear more than once in this translation
-            ERROR: Specifier for argument 2 does not match (should be @, is ld)
+            WARNING: 'bad pos %ld %@' does not include argument(s) at 1 (string_has_missing_arguments)
+            WARNING: Some arguments appear more than once in this translation (string_has_duplicate_arguments)
+            ERROR: Specifier for argument 2 does not match (should be @, is ld) (string_has_invalid_argument)
           bad position %d:
-            WARNING: 'bad position %d' does not include argument(s) at 1
+            WARNING: 'bad position %d' does not include argument(s) at 1 (string_has_missing_arguments)
           mismatch %@ types %d:
-            ERROR: Specifier for argument 2 does not match (should be d, is @)
-            ERROR: Specifier for argument 1 does not match (should be @, is d)
+            ERROR: Specifier for argument 2 does not match (should be d, is @) (string_has_invalid_argument)
+            ERROR: Specifier for argument 1 does not match (should be @, is d) (string_has_invalid_argument)
         4 warnings, 3 errors
         Errors found
 
@@ -108,18 +107,18 @@ class ExecutableTests: XCTestCase {
         Summary:
         Examples/Demo_Base.stringsdict
           %d/%d Completed:
-            WARNING: '%d/%d Completed' is missing from Demo_Translation
+            WARNING: '%d/%d Completed' is missing from Demo_Translation (key_missing_from_translation)
           %s added %d task(s) to 's':
-            WARNING: '%s added %d task(s) to 's'' is missing from Demo_Translation
-            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added %d tasks and %d milestones to %3$s' uses 's'.
-            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added %d tasks and a milestone to %3$s' uses 's'.
-            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added a task and %d milestones to %3$s' uses 's'.
-            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added a task and a milestone to %3$s' uses 's'.
+            WARNING: '%s added %d task(s) to 's'' is missing from Demo_Translation (key_missing_from_translation)
+            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added %d tasks and %d milestones to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
+            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added %d tasks and a milestone to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
+            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added a task and %d milestones to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
+            ERROR: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added a task and a milestone to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
           missing from translation:
-            WARNING: 'missing from translation' is missing from Demo_Translation
+            WARNING: 'missing from translation' is missing from Demo_Translation (key_missing_from_translation)
         Examples/Demo_Translation.stringsdict
           missing from base:
-            WARNING: 'missing from base' is missing from the base translation
+            WARNING: 'missing from base' is missing from the base translation (key_missing_from_base)
         4 warnings, 4 errors
         Errors found
 


### PR DESCRIPTION
This was a really helpful test case because it revealed some bugs in how we read files.

1. `--ignore-warnings` flag. Wikipedia's warnings are all spurious.
2. Stop trying to do a 1:1 mapping of `.strings` files. Instead, combine all strings file values into a single list and compare the lists.
3. Support UTF-16 encoding by retrying file reading if the first read fails with a certain error.
4. Append problem kind to summary lines to make it easier to ignore specific things.
5. File-level errors are now reported in the summary instead of only in the line-by-line stderr errors.
6. Strip common prefix from summary when using `discover*` commands for readability

Example below. The errors aren't really errors for Wikipedia specifically, but I'm not comfortable downgrading them to warnings without a lot more thought, because these errors would really be errors in the Asana app. Looking at the actual strings, it appears they use a custom localization system, so I'm not worried about it.

```
> swift run locheck discoverlproj ~/dev/3p/wikipedia-ios/Wikipedia/iOS\ Native\ Localizations --ignore-warnings
Discovering .lproj files in /Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations with en as the base
Source of truth: /Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/en.lproj/
Translations to check: 108
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/eu.lproj/Localizable.stringsdict:22: error: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/eu.lproj/Localizable.stringsdict:166: error: 'reading-lists-delete-reading-list-alert-title' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/eu.lproj/Localizable.stringsdict:297: error: 'saved-unsave-article-and-remove-from-reading-lists-title' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/ga.lproj/Localizable.stringsdict:6: error: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/id.lproj/Localizable.stringsdict:6: error: 'aaald-characters-text-description' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/nqo.lproj/Localizable.stringsdict:38: error: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
/Users/stevelandey/dev/3p/wikipedia-ios/Wikipedia/iOS Native Localizations/uk.lproj/Localizable.stringsdict:120: error: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)

Summary:
eu.lproj/Localizable.stringsdict
  article-deleted-accessibility-notification:
    ERROR: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
  reading-lists-delete-reading-list-alert-title:
    ERROR: 'reading-lists-delete-reading-list-alert-title' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
  saved-unsave-article-and-remove-from-reading-lists-title:
    ERROR: 'saved-unsave-article-and-remove-from-reading-lists-title' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
ga.lproj/Localizable.stringsdict
  article-deleted-accessibility-notification:
    ERROR: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
id.lproj/Localizable.stringsdict
  aaald-characters-text-description:
    ERROR: 'aaald-characters-text-description' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
nqo.lproj/Localizable.stringsdict
  article-deleted-accessibility-notification:
    ERROR: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
uk.lproj/Localizable.stringsdict
  article-deleted-accessibility-notification:
    ERROR: 'article-deleted-accessibility-notification' has more arguments than the base language. Extra args: d (stringsdict_entry_has_too_many_arguments)
0 warnings, 7 errors
Errors found
```

Fix #18