### PR TITLE
Extend `stringPairRegex` to accept more valid lines

### DIFF
--- a/Sources/LocheckLogic/Expressions.swift
+++ b/Sources/LocheckLogic/Expressions.swift
@@ -17,10 +17,11 @@ struct Expressions {
 
     // https://stackoverflow.com/a/37032779
     private static let stringLiteralExpression = #""[^"\\]*(\\.[^"\\]*)*""#
-    private static let greedyCommentExpression = #"/\\*.*\\*/"#
-    private static let commentExpression = #"/\\*.*?\\*/"#
+    private static let greedyBlockCommentExpression = #"/\\*.*\\*/"#
+    private static let blockCommentExpression = #"/\\*.*?\\*/"#
+    private static let commentExpression = #"//.*"#
     private static let stringPairExpression =
-        "^(?:\\s*\(commentExpression)\\s*)*(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));(?:\\s*\(greedyCommentExpression)\\s*)?$"
+        "^(?:\\s*\(blockCommentExpression)\\s*)*(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));(?:\\s*\(greedyBlockCommentExpression)\\s*|\\s*\(commentExpression))?$"
     static let stringPairRegex = try! NSRegularExpression(
         pattern: Expressions.stringPairExpression,
         options: .anchorsMatchLines)

--- a/Sources/LocheckLogic/Expressions.swift
+++ b/Sources/LocheckLogic/Expressions.swift
@@ -21,7 +21,7 @@ struct Expressions {
     private static let blockCommentExpression = #"/\\*.*?\\*/"#
     private static let commentExpression = #"//.*"#
     private static let stringPairExpression =
-        "^(?:\\s*\(blockCommentExpression)\\s*)*(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));(?:\\s*\(greedyBlockCommentExpression)\\s*|\\s*\(commentExpression))?$"
+        "^(?:\\s*\(blockCommentExpression)\\s*)*(?<key>\(stringLiteralExpression)) *= *(?<value>\(stringLiteralExpression));(?:\\s*\(greedyBlockCommentExpression)\\s*|\\s*\(commentExpression))?$"
     static let stringPairRegex = try! NSRegularExpression(
         pattern: Expressions.stringPairExpression,
         options: .anchorsMatchLines)

--- a/Sources/LocheckLogic/Expressions.swift
+++ b/Sources/LocheckLogic/Expressions.swift
@@ -17,9 +17,10 @@ struct Expressions {
 
     // https://stackoverflow.com/a/37032779
     private static let stringLiteralExpression = #""[^"\\]*(\\.[^"\\]*)*""#
-    private static let commentExpression = #"/\\*.*\\*/"#
+    private static let greedyCommentExpression = #"/\\*.*\\*/"#
+    private static let commentExpression = #"/\\*.*?\\*/"#
     private static let stringPairExpression =
-        "^(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));(?:\\s*\(commentExpression)\\s*)?$"
+        "^(?:\\s*\(commentExpression)\\s*)*(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));(?:\\s*\(greedyCommentExpression)\\s*)?$"
     static let stringPairRegex = try! NSRegularExpression(
         pattern: Expressions.stringPairExpression,
         options: .anchorsMatchLines)

--- a/Sources/LocheckLogic/Expressions.swift
+++ b/Sources/LocheckLogic/Expressions.swift
@@ -17,8 +17,9 @@ struct Expressions {
 
     // https://stackoverflow.com/a/37032779
     private static let stringLiteralExpression = #""[^"\\]*(\\.[^"\\]*)*""#
+    private static let commentExpression = #"/\\*.*\\*/"#
     private static let stringPairExpression =
-        "^(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));$"
+        "^(?<key>\(stringLiteralExpression)) = (?<value>\(stringLiteralExpression));(?:\\s*\(commentExpression)\\s*)?$"
     static let stringPairRegex = try! NSRegularExpression(
         pattern: Expressions.stringPairExpression,
         options: .anchorsMatchLines)

--- a/Tests/LocheckCommandTests/LocalizedStringPairTests.swift
+++ b/Tests/LocheckCommandTests/LocalizedStringPairTests.swift
@@ -70,4 +70,51 @@ class LocalizedStringPairTests: XCTestCase {
             ])
         XCTAssertTrue(problemReporter.problems.isEmpty)
     }
+
+    func testVariableSpacing() {
+        let problemReporter = ProblemReporter(log: false)
+        // one space
+        XCTAssertNotNil(LocalizedStringPair(string: #""Test key" = "Test value";"#, path: "abc", line: 0))
+        // no spaces
+        XCTAssertNotNil(LocalizedStringPair(string: #""Test key"="Test value";"#, path: "abc", line: 0))
+        // mixed spaces
+        XCTAssertNotNil(LocalizedStringPair(string: #""Test key"= "Test value";"#, path: "abc", line: 0))
+        XCTAssertNotNil(LocalizedStringPair(string: #""Test key" ="Test value";"#, path: "abc", line: 0))
+        // multiple spaces
+        XCTAssertNotNil(LocalizedStringPair(string: #""Test key"  =  "Test value";"#, path: "abc", line: 0))
+        XCTAssertTrue(problemReporter.problems.isEmpty)
+    }
+
+    func testComments() {
+        let problemReporter = ProblemReporter(log: false)
+        // no comment
+        XCTAssertNotNil(LocalizedStringPair(string: #""Test key" = "Test value";"#, path: "abc", line: 0))
+        // block comment after
+        XCTAssertNotNil(LocalizedStringPair(
+            string: #""Test key" = "Test value"; /* this is a comment */"#,
+            path: "abc",
+            line: 0))
+        // multiple block comments after
+        XCTAssertNotNil(LocalizedStringPair(
+            string: #""Test key" = "Test value"; /* this is a comment */ /* this is another comment */"#,
+            path: "abc",
+            line: 0))
+        // block comment before
+        XCTAssertNotNil(LocalizedStringPair(
+            string: #"/* this is a comment */ "Test key" = "Test value";"#,
+            path: "abc",
+            line: 0))
+        // multiple block comment before
+        XCTAssertNotNil(LocalizedStringPair(
+            string: #"/* this is a comment */ /* this is also a comment */ "Test key" = "Test value";"#,
+            path: "abc",
+            line: 0))
+        // single-line comment after
+        XCTAssertNotNil(LocalizedStringPair(
+            string: #""Test key" = "Test value"; // this is a comment"#,
+            path: "abc",
+            line: 0))
+
+        XCTAssertTrue(problemReporter.problems.isEmpty)
+    }
 }


### PR DESCRIPTION
Currently, locheck will ignore lines in .strings files that contain comments. It will also ignore lines if there is not exactly one space character before and after the `=` character in the line. These forms are however considered valid by Xcode and should not be ignored.

This PR extends `stringPairRegex` to match and ignore comments at the beginning and end of lines, and adjusts the regex to match ` *= *` instead of ` = `.

Currently, the regex still does not handle multi-line block comments that begin or end on the same line as a valid key-value pair. I'm undecided if we should just allow unbalanced `*/` or `/*` patterns at the beginning or end of a line, respectively, or if a broader multi-line parser would be more appropriate.