### PR TITLE
Compare strings files 1-to-1 instead of all-to-all (fix #24)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,6 @@ only_rules:
   - balanced_xctest_lifecycle
   - class_delegate_protocol
   - closing_brace
-  - closure_end_indentation
   - closure_parameter_position
   - closure_spacing
   - collection_alignment

--- a/BadlyLocalizedApp/BadlyLocalizedApp/printLocalizationExamples.swift
+++ b/BadlyLocalizedApp/BadlyLocalizedApp/printLocalizationExamples.swift
@@ -19,6 +19,6 @@ func printLocalizationExamples() {
     print(NSLocalizedString("bad-order-causes-bad-type", comment: ""))
 //    print(String.localizedStringWithFormat(NSLocalizedString("bad-order-causes-bad-type", comment: ""), 2, "Steve"))
 
-        print(String.localizedStringWithFormat(NSLocalizedString("arg-order-test", comment: ""), "one", "two"))
+    print(String.localizedStringWithFormat(NSLocalizedString("arg-order-test", comment: ""), "one", "two"))
     print("Done")
 }

--- a/Examples/test-base.lproj/file1.strings
+++ b/Examples/test-base.lproj/file1.strings
@@ -1,0 +1,2 @@
+"in_both_files" = "This string is in file1 and file2";
+"just_in_file1" = "This string is just in file1";

--- a/Examples/test-base.lproj/file2.strings
+++ b/Examples/test-base.lproj/file2.strings
@@ -1,0 +1,1 @@
+"in_both_files" = "This string is in file1 and file2";

--- a/Examples/test-translation.lproj/file1.strings
+++ b/Examples/test-translation.lproj/file1.strings
@@ -1,0 +1,3 @@
+// missing just_in_file1
+// This will only cover file1, not file2
+"in_both_files" = "This string is in both files";

--- a/Examples/test-translation.lproj/file2.strings
+++ b/Examples/test-translation.lproj/file2.strings
@@ -1,0 +1,2 @@
+// missing in_both_files
+"just_in_file1" "This string is just in file1, but this is file2 so it will have an error";

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-nicklockwood/SwiftFormat@0.48.11
-realm/SwiftLint@0.43.1
+nicklockwood/SwiftFormat@0.48.17
+realm/SwiftLint@0.45.1

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -92,8 +92,8 @@ struct XCStrings: HasIgnoreWithShorthand, ParsableCommand {
             for file in translationFiles {
                 let translationFile = try! File(path: file.argument)
                 parseAndValidateXCStrings(
-                    base: [try! File(path: base.argument)],
-                    translation: [translationFile],
+                    base: try! File(path: base.argument),
+                    translation: translationFile,
                     translationLanguageName: translationFile.nameExcludingExtension,
                     problemReporter: problemReporter)
             }
@@ -307,7 +307,7 @@ struct DiscoverLproj: HasIgnoreWithShorthand, ParsableCommand {
                         validateLproj(base: baseLproj, translation: translation, problemReporter: problemReporter)
                     }
                     problemReporter.printSummary()
-            }
+                }
         }
     }
 }
@@ -387,7 +387,7 @@ struct DiscoverValues: HasIgnoreWithShorthand, ParsableCommand {
                             problemReporter: problemReporter)
                     }
                     problemReporter.printSummary()
-            }
+                }
         }
     }
 }

--- a/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
@@ -12,24 +12,23 @@ import Foundation
  Directly compare two `.strings` files
  */
 public func parseAndValidateXCStrings(
-    base: [File],
-    translation: [File],
+    base: File,
+    translation: File,
     translationLanguageName: String,
     problemReporter: ProblemReporter) {
-    let collectLines = { (files: [File], baseStringMap: [String: FormatString]) -> [LocalizedStringPair] in
-        files.flatMap { file in
-            file.lo_getLines(problemReporter: problemReporter)?
-                .enumerated()
-                .compactMap {
-                    LocalizedStringPair(
-                        string: $0.1,
-                        path: file.path,
-                        line: $0.0 + 1,
-                        baseStringMap: baseStringMap)
-                } ?? []
-        }
+    let collectLines = { (file: File, baseStringMap: [String: FormatString]) -> [LocalizedStringPair] in
+        file.lo_getLines(problemReporter: problemReporter)?
+            .enumerated()
+            .compactMap {
+                LocalizedStringPair(
+                    string: $0.1,
+                    path: file.path,
+                    line: $0.0 + 1,
+                    baseStringMap: baseStringMap)
+            } ?? []
     }
 
+    // Compare similarly-named files 1-to-1
     let baseStrings: [LocalizedStringPair] = collectLines(base, [:])
     guard !baseStrings.isEmpty else { return }
 

--- a/Sources/LocheckLogic/Validators/validateLproj.swift
+++ b/Sources/LocheckLogic/Validators/validateLproj.swift
@@ -12,11 +12,20 @@ import Foundation
  Directly compare `.strings` files with the same name across two `.lproj` files
  */
 public func validateLproj(base: LprojFiles, translation: LprojFiles, problemReporter: ProblemReporter) {
-    parseAndValidateXCStrings(
-        base: base.strings,
-        translation: translation.strings,
-        translationLanguageName: translation.name,
-        problemReporter: problemReporter)
+    for file in base.strings {
+        guard let counterpart = translation.strings.first(where: { $0.name == file.name }) else {
+            problemReporter.report(
+                LprojFileMissingFromTranslation(key: file.name, language: translation.name),
+                path: file.path,
+                lineNumber: 0)
+            return
+        }
+        parseAndValidateXCStrings(
+            base: file,
+            translation: counterpart,
+            translationLanguageName: translation.name,
+            problemReporter: problemReporter)
+    }
 
     for baseStringsdictFile in base.stringsdict {
         guard let translationStringsdictFile = translation.stringsdict

--- a/Tests/LocheckCommandTests/ExecutableTests.swift
+++ b/Tests/LocheckCommandTests/ExecutableTests.swift
@@ -50,7 +50,6 @@ class ExecutableTests: XCTestCase {
         let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
         let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
 
-        print(stdout!)
         XCTAssertEqual(stdout!, """
 
         Summary:
@@ -133,6 +132,46 @@ class ExecutableTests: XCTestCase {
         Examples/Demo_Base.stringsdict:81: error: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added %d tasks and a milestone to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
         Examples/Demo_Base.stringsdict:81: error: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added a task and %d milestones to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
         Examples/Demo_Base.stringsdict:81: error: Two permutations of '%s added %d task(s) to 's'' contain different format specifiers at position 3. '%s added %d tasks and %d milestones to %3$s' uses 'd', and '%s added a task and a milestone to %3$s' uses 's'. (stringsdict_entry_permutations_have_conflicting_specifiers)
+
+        """)
+    }
+
+    func testExampleOutput_lproj() throws {
+        let binary = productsDirectory.appendingPathComponent("locheck")
+
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = ["lproj", "Examples/test-base.lproj", "Examples/test-translation.lproj"]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+
+        XCTAssertEqual(stdout!, """
+        Validating 1 lproj files against test-base.lproj
+
+        Summary:
+        Examples/test-base.lproj/file1.strings
+          just_in_file1:
+            WARNING: 'just_in_file1' is missing from test-translation (key_missing_from_translation)
+        Examples/test-base.lproj/file2.strings
+          in_both_files:
+            WARNING: 'in_both_files' is missing from test-translation (key_missing_from_translation)
+        2 warnings, 0 errors
+        Finished validating
+
+        """)
+
+        XCTAssertEqual(stderr!, """
+        Examples/test-base.lproj/file1.strings:2: warning: 'just_in_file1' is missing from test-translation (key_missing_from_translation)
+        Examples/test-base.lproj/file2.strings:1: warning: 'in_both_files' is missing from test-translation (key_missing_from_translation)
 
         """)
     }


### PR DESCRIPTION
Instead of aggregating all .strings entries into one big list per lproj package, compare each to its similarly-named counterpart.

Fixes #24.