### PR TITLE
--treat-warnings-as-errors

### DIFF
--- a/BadlyLocalizedApp/BadlyLocalizedApp/printLocalizationExamples.swift
+++ b/BadlyLocalizedApp/BadlyLocalizedApp/printLocalizationExamples.swift
@@ -19,6 +19,6 @@ func printLocalizationExamples() {
     print(NSLocalizedString("bad-order-causes-bad-type", comment: ""))
 //    print(String.localizedStringWithFormat(NSLocalizedString("bad-order-causes-bad-type", comment: ""), 2, "Steve"))
 
-        print(String.localizedStringWithFormat(NSLocalizedString("arg-order-test", comment: ""), "one", "two"))
+    print(String.localizedStringWithFormat(NSLocalizedString("arg-order-test", comment: ""), "one", "two"))
     print("Done")
 }

--- a/Sources/LocheckCommand/main.swift
+++ b/Sources/LocheckCommand/main.swift
@@ -16,10 +16,10 @@ let version = "0.9.2"
 struct Locheck: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: """
-        Validate your Xcode localization files. Currently only works on .strings. The different
-        commands have different amounts of automation. `discover` operates on a directory of
-        .lproj files, `lproj` operates on specific .lproj files, and `strings` operates on
-        specific .strings files.
+        Validate your Xcode localization files. The different commands have
+        different amounts of automation. `discover` operates on a directory of
+        .lproj files, `lproj` operates on specific .lproj files, and `strings`
+        operates on specific .strings files.
         """,
         subcommands: [
             DiscoverLproj.self,
@@ -36,10 +36,11 @@ private func withProblemReporter(
     root: String,
     ignore: [String],
     ignoreWarnings: Bool,
+    treatWarningsAsErrors: Bool,
     _ block: (ProblemReporter) -> Void) {
     let problemReporter = ProblemReporter(root: root, ignoredProblemIdentifiers: ignore, ignoreWarnings: ignoreWarnings)
     block(problemReporter)
-    if problemReporter.hasError {
+    if problemReporter.hasError || (treatWarningsAsErrors && problemReporter.hasWarning) {
         print("Errors found")
         Darwin.exit(1)
     }
@@ -52,6 +53,9 @@ private let ignoreMissingHelpText: ArgumentHelp =
     "Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'."
 
 private let ignoreWarningsHelpText: ArgumentHelp = "Ignore all warning-level issues."
+
+private let treatWarningsAsErrorsHelpText: ArgumentHelp =
+    "Return a non-zero exit code if any warnings, not just errors, were encountered."
 
 private protocol HasIgnoreWithShorthand {
     var ignore: [String] { get }
@@ -81,24 +85,31 @@ struct XCStrings: HasIgnoreWithShorthand, ParsableCommand {
     @Flag(help: ignoreWarningsHelpText)
     fileprivate var ignoreWarnings = false
 
+    @Flag(help: treatWarningsAsErrorsHelpText)
+    fileprivate var treatWarningsAsErrors = false
+
     func validate() throws {
         try stringsFiles.forEach { try $0.validate(ext: "strings") }
     }
 
     func run() {
-        withProblemReporter(root: "", ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
-            let base = stringsFiles[0]
-            let translationFiles = stringsFiles.dropFirst()
-            for file in translationFiles {
-                let translationFile = try! File(path: file.argument)
-                parseAndValidateXCStrings(
-                    base: [try! File(path: base.argument)],
-                    translation: [translationFile],
-                    translationLanguageName: translationFile.nameExcludingExtension,
-                    problemReporter: problemReporter)
+        withProblemReporter(
+            root: "",
+            ignore: ignoreWithShorthand,
+            ignoreWarnings: ignoreWarnings,
+            treatWarningsAsErrors: treatWarningsAsErrors) { problemReporter in
+                let base = stringsFiles[0]
+                let translationFiles = stringsFiles.dropFirst()
+                for file in translationFiles {
+                    let translationFile = try! File(path: file.argument)
+                    parseAndValidateXCStrings(
+                        base: [try! File(path: base.argument)],
+                        translation: [translationFile],
+                        translationLanguageName: translationFile.nameExcludingExtension,
+                        problemReporter: problemReporter)
+                }
+                problemReporter.printSummary()
             }
-            problemReporter.printSummary()
-        }
     }
 }
 
@@ -119,32 +130,39 @@ struct AndroidStrings: HasIgnoreWithShorthand, ParsableCommand {
     @Flag(help: ignoreWarningsHelpText)
     fileprivate var ignoreWarnings = false
 
+    @Flag(help: treatWarningsAsErrorsHelpText)
+    fileprivate var treatWarningsAsErrors = false
+
     func validate() throws {
         try stringsFiles.forEach { try $0.validate(ext: "xml") }
     }
 
     func run() {
-        withProblemReporter(root: "", ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
-            let baseFile = stringsFiles[0]
-            let translationFiles = stringsFiles.dropFirst()
-            if translationFiles.isEmpty {
-                // Just do what we can with the base language, i.e. validate plurals
-                _ = AndroidStringsFile(path: baseFile.argument, problemReporter: problemReporter)
-            }
-            for file in translationFiles {
-                let translationFile = try! File(path: file.argument)
-                var translationLanguageName = translationFile.parent!.nameExcludingExtension
-                if translationLanguageName.hasPrefix("values-") {
-                    translationLanguageName = String(translationLanguageName.dropFirst("values-".count))
+        withProblemReporter(
+            root: "",
+            ignore: ignoreWithShorthand,
+            ignoreWarnings: ignoreWarnings,
+            treatWarningsAsErrors: treatWarningsAsErrors) { problemReporter in
+                let baseFile = stringsFiles[0]
+                let translationFiles = stringsFiles.dropFirst()
+                if translationFiles.isEmpty {
+                    // Just do what we can with the base language, i.e. validate plurals
+                    _ = AndroidStringsFile(path: baseFile.argument, problemReporter: problemReporter)
                 }
-                parseAndValidateAndroidStrings(
-                    base: try! File(path: baseFile.argument),
-                    translation: translationFile,
-                    translationLanguageName: translationLanguageName,
-                    problemReporter: problemReporter)
+                for file in translationFiles {
+                    let translationFile = try! File(path: file.argument)
+                    var translationLanguageName = translationFile.parent!.nameExcludingExtension
+                    if translationLanguageName.hasPrefix("values-") {
+                        translationLanguageName = String(translationLanguageName.dropFirst("values-".count))
+                    }
+                    parseAndValidateAndroidStrings(
+                        base: try! File(path: baseFile.argument),
+                        translation: translationFile,
+                        translationLanguageName: translationLanguageName,
+                        problemReporter: problemReporter)
+                }
+                problemReporter.printSummary()
             }
-            problemReporter.printSummary()
-        }
     }
 }
 
@@ -164,30 +182,38 @@ struct Stringsdict: HasIgnoreWithShorthand, ParsableCommand {
     @Flag(help: ignoreWarningsHelpText)
     fileprivate var ignoreWarnings = false
 
+    @Flag(help: treatWarningsAsErrorsHelpText)
+    fileprivate var treatWarningsAsErrors = false
+
     func validate() throws {
         try stringsdictFiles.forEach { try $0.validate(ext: "stringsdict") }
     }
 
     func run() {
-        withProblemReporter(root: "", ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
-            let baseFile = stringsdictFiles[0]
-            let translationFiles = stringsdictFiles.dropFirst()
-            // Just do what we can with the base language, i.e. validate plurals
-            if translationFiles.isEmpty, let stringsdictFile = StringsdictFile(
-                path: baseFile.argument,
-                problemReporter: problemReporter) {
-                stringsdictFile.entries.forEach { _ = $0.getCanonicalArgumentList(problemReporter: problemReporter) }
+        withProblemReporter(
+            root: "",
+            ignore: ignoreWithShorthand,
+            ignoreWarnings: ignoreWarnings,
+            treatWarningsAsErrors: treatWarningsAsErrors) { problemReporter in
+                let baseFile = stringsdictFiles[0]
+                let translationFiles = stringsdictFiles.dropFirst()
+                // Just do what we can with the base language, i.e. validate plurals
+                if translationFiles.isEmpty, let stringsdictFile = StringsdictFile(
+                    path: baseFile.argument,
+                    problemReporter: problemReporter) {
+                    stringsdictFile.entries
+                        .forEach { _ = $0.getCanonicalArgumentList(problemReporter: problemReporter) }
+                }
+                for file in translationFiles {
+                    let translationFile = try! File(path: file.argument)
+                    parseAndValidateStringsdict(
+                        base: try! File(path: baseFile.argument),
+                        translation: translationFile,
+                        translationLanguageName: translationFile.nameExcludingExtension,
+                        problemReporter: problemReporter)
+                }
+                problemReporter.printSummary()
             }
-            for file in translationFiles {
-                let translationFile = try! File(path: file.argument)
-                parseAndValidateStringsdict(
-                    base: try! File(path: baseFile.argument),
-                    translation: translationFile,
-                    translationLanguageName: translationFile.nameExcludingExtension,
-                    problemReporter: problemReporter)
-            }
-            problemReporter.printSummary()
-        }
     }
 }
 
@@ -207,6 +233,9 @@ struct Lproj: HasIgnoreWithShorthand, ParsableCommand {
     @Flag(help: ignoreWarningsHelpText)
     fileprivate var ignoreWarnings = false
 
+    @Flag(help: treatWarningsAsErrorsHelpText)
+    fileprivate var treatWarningsAsErrors = false
+
     func validate() throws {
         try lprojFiles.forEach { try $0.validate(ext: "lproj") }
     }
@@ -219,21 +248,25 @@ struct Lproj: HasIgnoreWithShorthand, ParsableCommand {
                 "Validating \(translationFiles.count) lproj files against \(try! Folder(path: baseFile.argument).name)")
         }
 
-        withProblemReporter(root: "", ignore: ignoreWithShorthand, ignoreWarnings: ignoreWarnings) { problemReporter in
-            // Same as in DiscoverLproj command below
-            if translationFiles.isEmpty {
-                // Just do what we can with the base language, i.e. validate plurals
-                let lprojFiles = LprojFiles(folder: try! Folder(path: baseFile.argument))
-                lprojFiles.validateInternally(problemReporter: problemReporter)
+        withProblemReporter(
+            root: "",
+            ignore: ignoreWithShorthand,
+            ignoreWarnings: ignoreWarnings,
+            treatWarningsAsErrors: treatWarningsAsErrors) { problemReporter in
+                // Same as in DiscoverLproj command below
+                if translationFiles.isEmpty {
+                    // Just do what we can with the base language, i.e. validate plurals
+                    let lprojFiles = LprojFiles(folder: try! Folder(path: baseFile.argument))
+                    lprojFiles.validateInternally(problemReporter: problemReporter)
+                }
+                for translation in translationFiles {
+                    validateLproj(
+                        base: LprojFiles(folder: try! Folder(path: baseFile.argument)),
+                        translation: LprojFiles(folder: try! Folder(path: translation.argument)),
+                        problemReporter: problemReporter)
+                }
+                problemReporter.printSummary()
             }
-            for translation in translationFiles {
-                validateLproj(
-                    base: LprojFiles(folder: try! Folder(path: baseFile.argument)),
-                    translation: LprojFiles(folder: try! Folder(path: translation.argument)),
-                    problemReporter: problemReporter)
-            }
-            problemReporter.printSummary()
-        }
     }
 }
 
@@ -257,6 +290,9 @@ struct DiscoverLproj: HasIgnoreWithShorthand, ParsableCommand {
 
     @Flag(help: ignoreWarningsHelpText)
     fileprivate var ignoreWarnings = false
+
+    @Flag(help: treatWarningsAsErrorsHelpText)
+    fileprivate var treatWarningsAsErrors = false
 
     func validate() throws {
         for directory in directories {
@@ -296,7 +332,8 @@ struct DiscoverLproj: HasIgnoreWithShorthand, ParsableCommand {
             withProblemReporter(
                 root: directory.argument,
                 ignore: ignoreWithShorthand,
-                ignoreWarnings: ignoreWarnings) { problemReporter in
+                ignoreWarnings: ignoreWarnings,
+                treatWarningsAsErrors: treatWarningsAsErrors) { problemReporter in
                     // Same as in Lproj command above
                     if translationLproj.isEmpty {
                         // Just do what we can with the base language, i.e. validate plurals
@@ -307,7 +344,7 @@ struct DiscoverLproj: HasIgnoreWithShorthand, ParsableCommand {
                         validateLproj(base: baseLproj, translation: translation, problemReporter: problemReporter)
                     }
                     problemReporter.printSummary()
-            }
+                }
         }
     }
 }
@@ -328,6 +365,9 @@ struct DiscoverValues: HasIgnoreWithShorthand, ParsableCommand {
 
     @Flag(help: ignoreWarningsHelpText)
     fileprivate var ignoreWarnings = false
+
+    @Flag(help: treatWarningsAsErrorsHelpText)
+    fileprivate var treatWarningsAsErrors = false
 
     func validate() throws {
         for directory in directories {
@@ -378,7 +418,8 @@ struct DiscoverValues: HasIgnoreWithShorthand, ParsableCommand {
             withProblemReporter(
                 root: directory.argument,
                 ignore: ignoreWithShorthand,
-                ignoreWarnings: ignoreWarnings) { problemReporter in
+                ignoreWarnings: ignoreWarnings,
+                treatWarningsAsErrors: treatWarningsAsErrors) { problemReporter in
                     for translation in translationValues {
                         parseAndValidateAndroidStrings(
                             base: primaryValues,
@@ -387,7 +428,7 @@ struct DiscoverValues: HasIgnoreWithShorthand, ParsableCommand {
                             problemReporter: problemReporter)
                     }
                     problemReporter.printSummary()
-            }
+                }
         }
     }
 }

--- a/Sources/LocheckLogic/ProblemReporter.swift
+++ b/Sources/LocheckLogic/ProblemReporter.swift
@@ -135,6 +135,14 @@ public class ProblemReporter {
     }
 
     /**
+     Returns true iff a `.warning`-severity problem has been reported. Returns `false` if no problems
+     or only errors were reported.
+     */
+    public var hasWarning: Bool {
+        problems.contains(where: { $0.problem.severity == .warning })
+    }
+
+    /**
      Returns true iff an `.error`-severity problem has been reported. Returns `false` if no problems
      or only warnings were reported.
      */


### PR DESCRIPTION
Fix #26. Adds a `--treat-warnings-as-errors` flag to every command that causes warnings to result in a nonzero exit code even without errors.

I skipped unit tests because this code is very obvious. I did make test files by hand and verify the behavior.