### PR TITLE
Fix a bug where xcstrings files would be missed.

### DIFF
--- a/Sources/LocheckLogic/Validators/validateLproj.swift
+++ b/Sources/LocheckLogic/Validators/validateLproj.swift
@@ -18,7 +18,7 @@ public func validateLproj(base: LprojFiles, translation: LprojFiles, problemRepo
                 LprojFileMissingFromTranslation(key: file.name, language: translation.name),
                 path: file.path,
                 lineNumber: 0)
-            return
+            continue
         }
         parseAndValidateXCStrings(
             base: file,


### PR DESCRIPTION
This PR fixes a bug where locheck stops checking any remaining xcstrings files as soon as it encounters a single file that is missing.