### PR TITLE
Update iOS example flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ There are a few ways to invoke `locheck` depending on how much magic you want. I
 The simplest way to use Locheck with Xcode is to use `discoverlproj` and point to a directory containing all your `.lproj` files:
 
 ```sh
-locheck discoverlproj "MyApp/Supporting Files" --default en # use English as the base language
+locheck discoverlproj "MyApp/Supporting Files" --base en # use English as the base language
 ```
 
 If you use a language besides English as your base, you'll need to pass it as an argument as shown in the example. Locheck does not try to read your xcodeproj file to figure it out.


### PR DESCRIPTION
`--default` doesn't exist and it's not mentioned in help. I think it was meant to be `--base`:

```
OVERVIEW: Automatically find .lproj files within a directory and compare them

USAGE: locheck discoverlproj [--base <base>] [<directories> ...] [--ignore <ignore> ...] [--ignore-missing] [--ignore-warnings] [--treat-warnings-as-errors]

ARGUMENTS:
  <directories>           One or more directories full of .lproj files, with one of them being authoritative (defined by --base). 

OPTIONS:
  --base <base>           The authoritative language. Defaults to 'en'.  (default: en)
  --ignore <ignore>       Ignore a rule completely. 
  --ignore-missing        Ignore 'missing string' errors. Shorthand for '--ignore key_missing_from_base --ignore key_missing_from_translation'. 
  --ignore-warnings       Ignore all warning-level issues. 
  --treat-warnings-as-errors
                          Return a non-zero exit code if any warnings, not just errors, were encountered. 
  -h, --help              Show help information.
```