### PR TITLE
Makefile: fix compilation on linux for Swift 6.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S), Darwin)
 	BUILD_PATH_PREFIX := .build/apple/Products/Release
-endif
-ifeq ($(UNAME_S), Linux)
+else ifeq ($(UNAME_S), Linux)
 	BUILD_PATH_PREFIX := .build/release
 endif
 
@@ -25,7 +24,11 @@ install: build
 	cp -f $(BUILD_PATH) $(INSTALL_PATH)
 
 build:
+ifeq ($(UNAME_S), Darwin) 
 	swift build --disable-sandbox -c release --arch arm64 --arch x86_64
+else ifeq ($(UNAME_S), Linux) 
+	swift build --disable-sandbox -c release
+endif
 
 uninstall:
 	rm -f $(INSTALL_PATH)


### PR DESCRIPTION
as specified in https://github.com/swiftlang/swift-package-manager/pull/2787/commits/d1fdbbfef0aec0bf6c5a0bff5e9c2c9bf23c6bb5 passing multiple archs is intended to allow compiling universal binaries in macOS.
When compiling for Swift 6, passing these arguments in linux fails due to the lack of xcode. For some reason this didn't prevent building prior to Swift 6.